### PR TITLE
feat(frontend): データブロック表示設定・コラプシブル・レーダー表示統合

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -148,6 +148,8 @@ Frontend/
 - マウスインタラクション
 - ズーム/パン機能
 
+**データブロック（ラベル）の ETA**: バックエンドの `eta` は ISO 8601（UTC インスタント）。ラベル上では **UTC（Zulu）の `HH:mm`** で表示し、ブラウザのローカルタイムゾーンには依存しない（詳細は [spec/20260318-data-block-display-items/spec.md](../spec/20260318-data-block-display-items/spec.md)）。**UTC / JST の切替**はデータブロック表示設定への項目追加で対応予定（[Issue #91](https://github.com/Futty93/Horus/issues/91)、`good first issue`）。
+
 ### 2. 航空機制御パネル (ControlAircraft)
 
 Operator 専用。管制官の音声指示を復唱した内容をバックエンドへ送信し、実際の航空機操作を行う。
@@ -206,8 +208,9 @@ React Context APIを使用して、以下の状態を管理しています：
 1. **中心座標** (CenterCoordinateContext)
 2. **表示範囲** (DisplayRangeContext)
 3. **経路情報表示設定** (RouteInfoDisplaySettingContext)
-4. **Fix選択モード** (SelectFixModeContext)
-5. **選択航空機** (SelectedAircraftContext) — callsign と instructedVector（altitude, groundSpeed, heading）
+4. **データブロック表示設定** (DataBlockDisplaySettingContext) — スクオーク・機種・ETA の表示 ON/OFF
+5. **Fix選択モード** (SelectFixModeContext)
+6. **選択航空機** (SelectedAircraftContext) — callsign と instructedVector（altitude, groundSpeed, heading）
 
 ## API通信
 

--- a/Frontend/app/controller/page.tsx
+++ b/Frontend/app/controller/page.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import RadarCanvas from "@/components/radarCanvas";
 import { RouteInfoDisplaySettingProvider } from "@/context/routeInfoDisplaySettingContext";
 import RouteInfoDisplaySetting from "@/components/routeInfoDisplaySetting";
-import SectorSelector from "@/components/sectorSelector";
 import { CenterCoordinateProvider } from "@/context/centerCoordinateContext";
 import { DisplayRangeProvider } from "@/context/displayRangeContext";
-import DisplayRangeSetting from "@/components/displayRangeSetting";
 import { RangeRingsSettingProvider } from "@/context/rangeRingsSettingContext";
-import RangeRingsSetting from "@/components/rangeRingsSetting";
+import RadarViewSetting from "@/components/radarViewSetting";
+import { DataBlockDisplaySettingProvider } from "@/context/dataBlockDisplaySettingContext";
+import DataBlockDisplaySetting from "@/components/dataBlockDisplaySetting";
 import { SelectFixModeProvider } from "@/context/selectFixModeContext";
 import { SelectedAircraftProvider } from "@/context/selectedAircraftContext";
 // import SelectFixMode from "@/components/selectFixMode";
@@ -26,35 +26,36 @@ export default function ControllerPage() {
       <CenterCoordinateProvider>
         <DisplayRangeProvider>
           <RangeRingsSettingProvider>
-            <SelectFixModeProvider>
-              <SelectedAircraftProvider>
-                <div className="flex h-screen w-full">
-                  <div className="flex w-full">
-                    <RadarCanvas />
-                    <div
-                      className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
+            <DataBlockDisplaySettingProvider>
+              <SelectFixModeProvider>
+                <SelectedAircraftProvider>
+                  <div className="flex h-screen w-full">
+                    <div className="flex w-full">
+                      <RadarCanvas />
+                      <div
+                        className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
                               p-4 flex flex-col justify-between min-w-80 max-w-80
                               h-full overflow-y-auto overflow-x-hidden
                               scrollbar-thin scrollbar-track-atc scrollbar-thumb-atc"
-                    >
-                      <div className="flex-1 space-y-4 min-h-0">
-                        <SelectedCallsignDisplay variant="controller" />
-                        <FlightPlanDisplay />
-                        <InstructionMemo />
-                      </div>
-                      <div id="settingArea" className="mt-4 space-y-4">
-                        <RouteInfoDisplaySetting />
-                        <div className="flex flex-col space-y-3">
-                          <SectorSelector />
-                          <DisplayRangeSetting />
-                          <RangeRingsSetting />
+                      >
+                        <div className="flex-1 space-y-4 min-h-0">
+                          <SelectedCallsignDisplay variant="controller" />
+                          <FlightPlanDisplay />
+                          <InstructionMemo />
+                        </div>
+                        <div id="settingArea" className="mt-4 space-y-4">
+                          <RouteInfoDisplaySetting />
+                          <div className="flex flex-col space-y-3">
+                            <RadarViewSetting />
+                            <DataBlockDisplaySetting />
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              </SelectedAircraftProvider>
-            </SelectFixModeProvider>
+                </SelectedAircraftProvider>
+              </SelectFixModeProvider>
+            </DataBlockDisplaySettingProvider>
           </RangeRingsSettingProvider>
         </DisplayRangeProvider>
       </CenterCoordinateProvider>

--- a/Frontend/app/operator/page.tsx
+++ b/Frontend/app/operator/page.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import RadarCanvas from "@/components/radarCanvas";
 import { RouteInfoDisplaySettingProvider } from "@/context/routeInfoDisplaySettingContext";
 import RouteInfoDisplaySetting from "@/components/routeInfoDisplaySetting";
-import SectorSelector from "@/components/sectorSelector";
 import { CenterCoordinateProvider } from "@/context/centerCoordinateContext";
 import { DisplayRangeProvider } from "@/context/displayRangeContext";
-import DisplayRangeSetting from "@/components/displayRangeSetting";
 import { RangeRingsSettingProvider } from "@/context/rangeRingsSettingContext";
-import RangeRingsSetting from "@/components/rangeRingsSetting";
+import RadarViewSetting from "@/components/radarViewSetting";
+import { DataBlockDisplaySettingProvider } from "@/context/dataBlockDisplaySettingContext";
+import DataBlockDisplaySetting from "@/components/dataBlockDisplaySetting";
 import ControlAircraft from "@/components/controlAircraft";
 import { SelectFixModeProvider } from "@/context/selectFixModeContext";
 import { SelectedAircraftProvider } from "@/context/selectedAircraftContext";
@@ -27,41 +27,42 @@ export default function OperatorPage() {
       <CenterCoordinateProvider>
         <DisplayRangeProvider>
           <RangeRingsSettingProvider>
-            <SelectFixModeProvider>
-              <SelectedAircraftProvider>
-                <div className="flex h-screen w-full overflow-hidden">
-                  <div className="flex w-full h-full">
-                    <RadarCanvas />
-                    <div
-                      className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
+            <DataBlockDisplaySettingProvider>
+              <SelectFixModeProvider>
+                <SelectedAircraftProvider>
+                  <div className="flex h-screen w-full overflow-hidden">
+                    <div className="flex w-full h-full">
+                      <RadarCanvas />
+                      <div
+                        className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
                                   p-3 flex flex-col min-w-80 max-w-80
                                   h-full overflow-y-auto overflow-x-hidden
                                   scrollbar-thin scrollbar-track-atc scrollbar-thumb-atc"
-                    >
-                      <SelectedCallsignDisplay variant="operator" />
+                      >
+                        <SelectedCallsignDisplay variant="operator" />
 
-                      {/* Scrollable Content */}
-                      <div className="flex-1 space-y-4 min-h-0">
-                        <ControlAircraft />
-                        <SelectFixMode />
-                        <FlightPlanControl />
+                        {/* Scrollable Content */}
+                        <div className="flex-1 space-y-4 min-h-0">
+                          <ControlAircraft />
+                          <SelectFixMode />
+                          <FlightPlanControl />
 
-                        {/* Settings Area */}
-                        <div className="space-y-3">
-                          <RouteInfoDisplaySetting />
-                          <SectorSelector />
-                          <DisplayRangeSetting />
-                          <RangeRingsSetting />
+                          {/* Settings Area */}
+                          <div className="space-y-3">
+                            <RouteInfoDisplaySetting />
+                            <RadarViewSetting />
+                            <DataBlockDisplaySetting />
 
-                          {/* Control Buttons */}
-                          <SimulationControlButtons />
+                            {/* Control Buttons */}
+                            <SimulationControlButtons />
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              </SelectedAircraftProvider>
-            </SelectFixModeProvider>
+                </SelectedAircraftProvider>
+              </SelectFixModeProvider>
+            </DataBlockDisplaySettingProvider>
           </RangeRingsSettingProvider>
         </DisplayRangeProvider>
       </CenterCoordinateProvider>

--- a/Frontend/components/dataBlockDisplaySetting.tsx
+++ b/Frontend/components/dataBlockDisplaySetting.tsx
@@ -1,0 +1,69 @@
+"use client";
+import React from "react";
+import CollapsiblePanel from "@/components/ui/collapsiblePanel";
+import { useDataBlockDisplaySetting } from "@/context/dataBlockDisplaySettingContext";
+
+const DataBlockDisplaySetting = () => {
+  const { dataBlockDisplaySetting, setDataBlockDisplaySetting } =
+    useDataBlockDisplaySetting();
+
+  const activeItems: string[] = [];
+  if (dataBlockDisplaySetting.aircraftType) activeItems.push("機種");
+  if (dataBlockDisplaySetting.eta) activeItems.push("ETA");
+  if (dataBlockDisplaySetting.squawk) activeItems.push("スクオーク");
+
+  const summary =
+    activeItems.length > 0 ? activeItems.join(", ") : "追加項目なし";
+
+  return (
+    <CollapsiblePanel title="データブロック" summary={summary}>
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={dataBlockDisplaySetting.aircraftType}
+            onChange={(e) =>
+              setDataBlockDisplaySetting((prev) => ({
+                ...prev,
+                aircraftType: e.target.checked,
+              }))
+            }
+            className="rounded border-atc-border bg-atc-surface-elevated text-atc-accent focus:ring-atc-accent"
+          />
+          <span className="text-atc-text text-xs">機種</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={dataBlockDisplaySetting.eta}
+            onChange={(e) =>
+              setDataBlockDisplaySetting((prev) => ({
+                ...prev,
+                eta: e.target.checked,
+              }))
+            }
+            className="rounded border-atc-border bg-atc-surface-elevated text-atc-accent focus:ring-atc-accent"
+          />
+          <span className="text-atc-text text-xs">ETA</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={dataBlockDisplaySetting.squawk}
+            onChange={(e) =>
+              setDataBlockDisplaySetting((prev) => ({
+                ...prev,
+                squawk: e.target.checked,
+              }))
+            }
+            className="rounded border-atc-border bg-atc-surface-elevated text-atc-accent focus:ring-atc-accent"
+          />
+          <span className="text-atc-text text-xs">スクオーク</span>
+          <span className="text-atc-text-muted text-xs">(3-1で有効化予定)</span>
+        </label>
+      </div>
+    </CollapsiblePanel>
+  );
+};
+
+export default DataBlockDisplaySetting;

--- a/Frontend/components/displayRangeSetting.tsx
+++ b/Frontend/components/displayRangeSetting.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { useDisplayRange } from "@/context/displayRangeContext";
 
-const DisplayRangeSetting = () => {
+const DisplayRangeSetting = ({ embedded = false }: { embedded?: boolean }) => {
   const { displayRange, setDisplayRange } = useDisplayRange();
 
   const handleRangeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -14,8 +14,8 @@ const DisplayRangeSetting = () => {
     console.log("Display range changed to:", newRange);
   };
 
-  return (
-    <div className="bg-atc-surface border border-atc-border rounded-lg p-3 mb-3">
+  const content = (
+    <>
       <div className="flex items-center justify-between">
         <label
           htmlFor="displayRange"
@@ -27,7 +27,7 @@ const DisplayRangeSetting = () => {
           <input
             type="number"
             id="displayRange"
-            defaultValue={`${displayRange.range}`}
+            value={displayRange.range}
             min="10"
             max="4000"
             onChange={handleRangeChange}
@@ -57,6 +57,15 @@ const DisplayRangeSetting = () => {
           }}
         />
       </div>
+    </>
+  );
+
+  if (embedded) {
+    return content;
+  }
+  return (
+    <div className="bg-atc-surface border border-atc-border rounded-lg p-3 mb-3">
+      {content}
     </div>
   );
 };

--- a/Frontend/components/radarCanvas.tsx
+++ b/Frontend/components/radarCanvas.tsx
@@ -14,6 +14,7 @@ import { useRouteInfoDisplaySetting } from "@/context/routeInfoDisplaySettingCon
 import { useCenterCoordinate } from "@/context/centerCoordinateContext";
 import { useDisplayRange } from "@/context/displayRangeContext";
 import { useRangeRingsSetting } from "@/context/rangeRingsSettingContext";
+import { useDataBlockDisplaySetting } from "@/context/dataBlockDisplaySettingContext";
 import { useSelectFixMode } from "@/context/selectFixModeContext";
 import { useSelectedAircraft } from "@/context/selectedAircraftContext";
 import { searchFixName } from "@/utility/AtsRouteManager/FixNameSearch";
@@ -47,6 +48,8 @@ const RadarCanvas: React.FC = () => {
   const displayRangeRef = useRef(displayRange);
   const { rangeRingsSetting } = useRangeRingsSetting();
   const rangeRingsSettingRef = useRef(rangeRingsSetting);
+  const { dataBlockDisplaySetting } = useDataBlockDisplaySetting();
+  const dataBlockDisplaySettingRef = useRef(dataBlockDisplaySetting);
   const { isSelectFixMode, setSelectedFixName } = useSelectFixMode();
   const {
     setCallsign,
@@ -160,6 +163,10 @@ const RadarCanvas: React.FC = () => {
   }, [rangeRingsSetting]);
 
   useEffect(() => {
+    dataBlockDisplaySettingRef.current = dataBlockDisplaySetting;
+  }, [dataBlockDisplaySetting]);
+
+  useEffect(() => {
     isSelectFixModeRef.current = isSelectFixMode;
   }, [isSelectFixMode]);
 
@@ -229,7 +236,12 @@ const RadarCanvas: React.FC = () => {
 
   const renderAircraftsOnCanvas = (ctx: CanvasRenderingContext2D) => {
     controllingAircraftsRef.current.forEach((aircraft) => {
-      DrawAircraft.drawAircraft(ctx, aircraft, displayRangeRef.current);
+      DrawAircraft.drawAircraft(
+        ctx,
+        aircraft,
+        displayRangeRef.current,
+        dataBlockDisplaySettingRef.current
+      );
     });
   };
 

--- a/Frontend/components/radarViewSetting.tsx
+++ b/Frontend/components/radarViewSetting.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React, { useState } from "react";
+import CollapsiblePanel from "@/components/ui/collapsiblePanel";
+import SectorSelector from "@/components/sectorSelector";
+import DisplayRangeSetting from "@/components/displayRangeSetting";
+import RangeRingsSetting from "@/components/rangeRingsSetting";
+import { useDisplayRange } from "@/context/displayRangeContext";
+import { useRangeRingsSetting } from "@/context/rangeRingsSettingContext";
+
+const RadarViewSetting = () => {
+  const [selectedSector, setSelectedSector] = useState("T09");
+  const { displayRange } = useDisplayRange();
+  const { rangeRingsSetting } = useRangeRingsSetting();
+
+  const rangeSummary = rangeRingsSetting.enabled
+    ? `${rangeRingsSetting.intervalNm}NM`
+    : "オフ";
+  const summary = `${selectedSector}, ${displayRange.range}km, レンジ${rangeSummary}`;
+
+  return (
+    <CollapsiblePanel title="レーダー表示" summary={summary}>
+      <div className="space-y-3">
+        <SectorSelector
+          embedded
+          value={selectedSector}
+          onChange={setSelectedSector}
+        />
+        <DisplayRangeSetting embedded />
+        <RangeRingsSetting embedded />
+      </div>
+    </CollapsiblePanel>
+  );
+};
+
+export default RadarViewSetting;

--- a/Frontend/components/rangeRingsSetting.tsx
+++ b/Frontend/components/rangeRingsSetting.tsx
@@ -5,11 +5,11 @@ import {
   RANGE_RINGS_INTERVAL_OPTIONS,
 } from "@/context/rangeRingsSettingContext";
 
-const RangeRingsSetting = () => {
+const RangeRingsSetting = ({ embedded = false }: { embedded?: boolean }) => {
   const { rangeRingsSetting, setRangeRingsSetting } = useRangeRingsSetting();
 
-  return (
-    <div className="bg-atc-surface border border-atc-border rounded-lg p-3 mb-3">
+  const content = (
+    <>
       <div className="flex items-center justify-between mb-2">
         <label className="font-bold text-atc-text font-mono tracking-wider text-xs">
           レンジリング:
@@ -58,6 +58,15 @@ const RangeRingsSetting = () => {
           </select>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) {
+    return content;
+  }
+  return (
+    <div className="bg-atc-surface border border-atc-border rounded-lg p-3 mb-3">
+      {content}
     </div>
   );
 };

--- a/Frontend/components/routeInfoDisplaySetting.tsx
+++ b/Frontend/components/routeInfoDisplaySetting.tsx
@@ -1,12 +1,28 @@
 "use client";
+import React from "react";
+import CollapsiblePanel from "@/components/ui/collapsiblePanel";
 import {
   useRouteInfoDisplaySetting,
   DisplaySettings,
 } from "@/context/routeInfoDisplaySettingContext";
 
+const SETTING_LABELS: Record<keyof DisplaySettings, string> = {
+  waypointName: "Wpt Name",
+  waypointPoint: "Wpt Point",
+  radioNavigationAidsName: "Nav Name",
+  radioNavigationAidsPoint: "Nav Point",
+  atsLowerRoute: "ATS Lower",
+  rnavRoute: "RNAV",
+};
+
 const RouteInfoDisplaySetting = () => {
   const { isDisplaying, setRouteInfoDisplaySetting } =
     useRouteInfoDisplaySetting();
+
+  const activeItems = (Object.keys(isDisplaying) as (keyof DisplaySettings)[])
+    .filter((k) => isDisplaying[k])
+    .map((k) => SETTING_LABELS[k]);
+  const summary = activeItems.length > 0 ? activeItems.join(", ") : "なし";
 
   const handleCheckboxChange = (settingKey: keyof DisplaySettings) => {
     return (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -76,14 +92,11 @@ const RouteInfoDisplaySetting = () => {
   );
 
   return (
-    <div
+    <CollapsiblePanel
       id="routeInfoDisplaySetting"
-      className="bg-atc-surface border border-atc-border rounded-lg p-2.5 mb-3"
+      title="ROUTE DISPLAY SETTINGS"
+      summary={summary}
     >
-      <h3 className="text-xs font-bold text-atc-text font-mono tracking-wider mb-2 text-center">
-        ROUTE DISPLAY SETTINGS
-      </h3>
-
       <div className="space-y-2">
         {[
           {
@@ -143,7 +156,7 @@ const RouteInfoDisplaySetting = () => {
           />
         </div>
       </div>
-    </div>
+    </CollapsiblePanel>
   );
 };
 

--- a/Frontend/components/sectorSelector.tsx
+++ b/Frontend/components/sectorSelector.tsx
@@ -2,8 +2,7 @@
 import { useCenterCoordinate } from "@/context/centerCoordinateContext";
 import { useState } from "react";
 
-// Define the sector center coordinates in a separate constant
-const sectorCenterCoordinates: {
+export const sectorCenterCoordinates: {
   [key: string]: { latitude: number; longitude: number };
 } = {
   T09: { latitude: 34.482, longitude: 138.614 },
@@ -55,69 +54,91 @@ const sectorCenterCoordinates: {
   A05: { latitude: 24.915694444444444, longitude: 132.88125 },
 };
 
-const SectorSelector = () => {
-  const [selectedSector, setSelectedSector] = useState("T09"); // Default sector
+interface SectorSelectorProps {
+  embedded?: boolean;
+  value?: string;
+  onChange?: (sector: string) => void;
+}
+
+const SectorSelector = ({
+  embedded = false,
+  value,
+  onChange,
+}: SectorSelectorProps) => {
+  const [internalSector, setInternalSector] = useState("T09");
   const { setCenterCoordinate } = useCenterCoordinate();
 
-  // Update the selected sector and call the callback
+  const isControlled = value !== undefined && onChange !== undefined;
+  const selectedSector = isControlled ? value : internalSector;
+
   const handleSectorChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const sector = event.target.value;
-    setSelectedSector(sector);
+    if (isControlled) {
+      onChange(sector);
+    } else {
+      setInternalSector(sector);
+    }
     setCenterCoordinate({
       latitude: sectorCenterCoordinates[sector].latitude,
       longitude: sectorCenterCoordinates[sector].longitude,
     });
-    console.log("Selected sector:", sector, sectorCenterCoordinates[sector]);
   };
 
-  return (
-    <div className="bg-atc-surface border border-atc-border rounded-lg p-3 mb-3">
-      <div className="flex items-center justify-between">
-        <label
-          htmlFor="selectSector"
-          className="font-bold text-atc-text font-mono tracking-wider text-xs"
-        >
-          担当セクター:
-        </label>
-        <div className="relative">
-          <select
-            id="selectSector"
-            value={selectedSector}
-            onChange={handleSectorChange}
-            className="appearance-none bg-atc-surface-elevated border border-atc-border rounded
+  const content = (
+    <div className="flex items-center justify-between">
+      <label
+        htmlFor="selectSector"
+        className="font-bold text-atc-text font-mono tracking-wider text-xs"
+      >
+        担当セクター:
+      </label>
+      <div className="relative">
+        <select
+          id="selectSector"
+          value={selectedSector}
+          onChange={handleSectorChange}
+          className="appearance-none bg-atc-surface-elevated border border-atc-border rounded
                        px-3 py-1 pr-7 text-atc-text font-mono text-xs
                        focus:outline-none focus:border-atc-accent
                        hover:border-atc-text-muted cursor-pointer"
-          >
-            {Object.keys(sectorCenterCoordinates).map((sector) => (
-              <option
-                key={sector}
-                value={sector}
-                className="bg-atc-surface-elevated text-atc-text"
-              >
-                {sector}
-              </option>
-            ))}
-          </select>
-
-          {/* Custom dropdown arrow */}
-          <div className="absolute inset-y-0 right-0 flex items-center pr-1 pointer-events-none">
-            <svg
-              className="w-3 h-3 text-atc-text-muted"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+        >
+          {Object.keys(sectorCenterCoordinates).map((sector) => (
+            <option
+              key={sector}
+              value={sector}
+              className="bg-atc-surface-elevated text-atc-text"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M19 9l-7 7-7-7"
-              ></path>
-            </svg>
-          </div>
+              {sector}
+            </option>
+          ))}
+        </select>
+
+        {/* Custom dropdown arrow */}
+        <div className="absolute inset-y-0 right-0 flex items-center pr-1 pointer-events-none">
+          <svg
+            className="w-3 h-3 text-atc-text-muted"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M19 9l-7 7-7-7"
+            ></path>
+          </svg>
         </div>
       </div>
+    </div>
+  );
+
+  if (embedded) {
+    return content;
+  }
+  return (
+    <div className="bg-atc-surface border border-atc-border rounded-lg p-3 mb-3">
+      {content}
     </div>
   );
 };

--- a/Frontend/components/ui/collapsiblePanel.tsx
+++ b/Frontend/components/ui/collapsiblePanel.tsx
@@ -1,0 +1,50 @@
+"use client";
+import React, { useState } from "react";
+
+interface CollapsiblePanelProps {
+  title: string;
+  summary: string;
+  children: React.ReactNode;
+  id?: string;
+  defaultExpanded?: boolean;
+}
+
+const CollapsiblePanel = ({
+  title,
+  summary,
+  children,
+  id,
+  defaultExpanded = false,
+}: CollapsiblePanelProps) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const contentId = id ? `${id}-content` : undefined;
+
+  return (
+    <div className="bg-atc-surface border border-atc-border rounded-lg p-2 mb-2">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        className="w-full flex items-center justify-between text-left gap-2"
+      >
+        <span className="font-bold text-atc-text font-mono tracking-wider text-xs">
+          {title}
+        </span>
+        <span className="text-atc-text-muted text-xs truncate flex-1 min-w-0">
+          {summary}
+        </span>
+        <span className="text-atc-text-muted text-xs shrink-0">
+          {expanded ? "▲" : "▼"}
+        </span>
+      </button>
+      {expanded && (
+        <div id={contentId} className="mt-2 pt-2 border-t border-atc-border">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CollapsiblePanel;

--- a/Frontend/context/dataBlockDisplaySettingContext.tsx
+++ b/Frontend/context/dataBlockDisplaySettingContext.tsx
@@ -1,0 +1,48 @@
+"use client";
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+export interface DataBlockDisplaySetting {
+  squawk: boolean;
+  aircraftType: boolean;
+  eta: boolean;
+}
+
+export interface DataBlockDisplaySettingContextType {
+  dataBlockDisplaySetting: DataBlockDisplaySetting;
+  setDataBlockDisplaySetting: React.Dispatch<
+    React.SetStateAction<DataBlockDisplaySetting>
+  >;
+}
+
+export const DataBlockDisplaySettingContext = createContext<
+  DataBlockDisplaySettingContextType | undefined
+>(undefined);
+
+export const DataBlockDisplaySettingProvider: React.FC<{
+  children: ReactNode;
+}> = ({ children }) => {
+  const [dataBlockDisplaySetting, setDataBlockDisplaySetting] =
+    useState<DataBlockDisplaySetting>({
+      squawk: false,
+      aircraftType: true,
+      eta: true,
+    });
+
+  return (
+    <DataBlockDisplaySettingContext.Provider
+      value={{ dataBlockDisplaySetting, setDataBlockDisplaySetting }}
+    >
+      {children}
+    </DataBlockDisplaySettingContext.Provider>
+  );
+};
+
+export const useDataBlockDisplaySetting = () => {
+  const context = useContext(DataBlockDisplaySettingContext);
+  if (!context) {
+    throw new Error(
+      "useDataBlockDisplaySetting must be used within a DataBlockDisplaySettingProvider"
+    );
+  }
+  return context;
+};

--- a/Frontend/utility/aircraft/aircraftClass.ts
+++ b/Frontend/utility/aircraft/aircraftClass.ts
@@ -9,7 +9,8 @@ export class Aircraft {
   originIcao: string;
   destinationIata: string;
   destinationIcao: string;
-  eta: string; // You may want to change this to a Date object if needed
+  /** ISO 8601 instant from API; data block shows UTC HH:mm (see spec 20260318-data-block-display-items). */
+  eta: string;
   label: { x: number; y: number };
   riskLevel: number; // 危険度（0-100）
 
@@ -17,7 +18,11 @@ export class Aircraft {
     callsign: string,
     position: { x: number; y: number; altitude: number },
     vector: { heading: number; groundSpeed: number; verticalSpeed: number },
-    instructedVector: { heading: number; groundSpeed: number; altitude: number },
+    instructedVector: {
+      heading: number;
+      groundSpeed: number;
+      altitude: number;
+    },
     type: string,
     model: string,
     originIata: string,

--- a/Frontend/utility/aircraft/drawAircraft.ts
+++ b/Frontend/utility/aircraft/drawAircraft.ts
@@ -1,10 +1,19 @@
-import { Display } from "next/dist/compiled/@next/font";
 import CoordinateManager from "../coordinateManager/CoordinateManager";
 import { GLOBAL_CONSTANTS } from "../globals/constants";
 import { GLOBAL_SETTINGS } from "../globals/settings";
 import { Aircraft } from "./aircraftClass";
 import { DisplayRange } from "@/context/displayRangeContext";
+import type { DataBlockDisplaySetting } from "@/context/dataBlockDisplaySettingContext";
 
+function formatEtaToHhMm(eta: string): string {
+  try {
+    const date = new Date(eta);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toTimeString().slice(0, 5);
+  } catch {
+    return "";
+  }
+}
 
 /**
  * Class to draw aircraft on the canvas
@@ -18,37 +27,51 @@ import { DisplayRange } from "@/context/displayRangeContext";
  * @see CanvasRenderingContext2D
  */
 class DrawAircraft {
-  public static drawAircraft(ctx: CanvasRenderingContext2D, aircraft: Aircraft, displayRange: DisplayRange) {
+  public static drawAircraft(
+    ctx: CanvasRenderingContext2D,
+    aircraft: Aircraft,
+    displayRange: DisplayRange,
+    dataBlockDisplaySetting: DataBlockDisplaySetting
+  ) {
     this.drawAircraftMarker(ctx, aircraft.position);
-    this.drawHeadingLine(ctx, aircraft.position, aircraft.vector.groundSpeed, aircraft.vector.heading, displayRange);
+    this.drawHeadingLine(
+      ctx,
+      aircraft.position,
+      aircraft.vector.groundSpeed,
+      aircraft.vector.heading,
+      displayRange
+    );
     this.drawLabelLiine(ctx, aircraft.position, aircraft.label);
-    this.drawAircraftLabel(ctx, aircraft);
+    this.drawAircraftLabel(ctx, aircraft, dataBlockDisplaySetting);
   }
 
-  private static drawAircraftMarker(ctx: CanvasRenderingContext2D, position: { x: number; y: number }) {
+  private static drawAircraftMarker(
+    ctx: CanvasRenderingContext2D,
+    position: { x: number; y: number }
+  ) {
     const radius: number = 5;
 
     // Draw aircraft as a filled white circle
     ctx.beginPath();
-    ctx.arc(
-      position.x,
-      position.y,
-      radius,
-      0,
-      2 * Math.PI,
-    );
+    ctx.arc(position.x, position.y, radius, 0, 2 * Math.PI);
     ctx.fillStyle = "white";
     ctx.fill();
   }
 
-  private static drawHeadingLine(ctx: CanvasRenderingContext2D, position: { x: number; y: number }, groundSpeed: number, heading: number, displayRange: DisplayRange) {
+  private static drawHeadingLine(
+    ctx: CanvasRenderingContext2D,
+    position: { x: number; y: number },
+    groundSpeed: number,
+    heading: number,
+    displayRange: DisplayRange
+  ) {
     const futurePosition = CoordinateManager.calculateFuturePositionOnCanvas(
       groundSpeed,
       heading,
       GLOBAL_SETTINGS.canvasWidth,
       GLOBAL_SETTINGS.canvasHeight,
       displayRange,
-      position,
+      position
     );
 
     // Draw a line from the current position to the future position
@@ -59,73 +82,109 @@ class DrawAircraft {
     ctx.stroke();
   }
 
-  private static drawAircraftLabel(ctx: CanvasRenderingContext2D, aircraft: Aircraft) {
+  private static drawAircraftLabel(
+    ctx: CanvasRenderingContext2D,
+    aircraft: Aircraft,
+    setting: DataBlockDisplaySetting
+  ) {
     const airplanePosition = aircraft.position;
     const instructedVector = aircraft.instructedVector;
     const labelX: number = airplanePosition.x + aircraft.label.x;
-    const labelY: number = airplanePosition.y - aircraft.label.y;
+    let lineY: number = airplanePosition.y - aircraft.label.y;
 
     let altitudeLabel: string = "";
-
     if (instructedVector.altitude > airplanePosition.altitude) {
-      altitudeLabel = Math.floor(instructedVector.altitude / 100).toString() + " ↑ " + Math.floor(airplanePosition.altitude / 100).toString();
+      altitudeLabel =
+        Math.floor(instructedVector.altitude / 100).toString() +
+        " ↑ " +
+        Math.floor(airplanePosition.altitude / 100).toString();
     } else if (instructedVector.altitude < airplanePosition.altitude) {
-      altitudeLabel = Math.floor(instructedVector.altitude / 100).toString() + " ↓ " + Math.floor(airplanePosition.altitude / 100).toString();
+      altitudeLabel =
+        Math.floor(instructedVector.altitude / 100).toString() +
+        " ↓ " +
+        Math.floor(airplanePosition.altitude / 100).toString();
     } else {
       altitudeLabel = Math.floor(airplanePosition.altitude / 100).toString();
     }
 
-    // 危険度情報を取得（デフォルトは0）
     const riskLevel = aircraft.riskLevel || 0;
-
-    // 危険度に基づく色の決定
-    let riskColor = "white"; // デフォルト（~30）
+    let riskColor = "white";
     if (riskLevel >= 70) {
-      riskColor = "red";     // 70以上は赤
+      riskColor = "red";
     } else if (riskLevel >= 30) {
-      riskColor = "yellow";  // 30-70は黄色
+      riskColor = "yellow";
     }
 
-    // Draw labels with airplane information
     ctx.fillStyle = "white";
     ctx.font = GLOBAL_CONSTANTS.FONT_STYLE_IN_CANVAS;
     ctx.textAlign = "left";
 
-    ctx.fillText(aircraft.callsign, labelX, labelY);
-    ctx.fillText(
-      altitudeLabel,
-      labelX,
-      labelY + 15,
-    );
-    ctx.fillText(
-      "G" + (Math.floor(aircraft.vector.groundSpeed / 10)).toString(),
-      labelX,
-      labelY + 30,
-    );
-    ctx.fillText(
-      aircraft.destinationIcao.length >= 4 ? aircraft.destinationIcao.slice(-3) : aircraft.destinationIcao,
-      labelX + 40,
-      labelY + 30,
-    );
+    const lineHeight = 15;
 
-    // 危険度を色分けして表示
-    ctx.fillStyle = riskColor;
+    ctx.fillText(aircraft.callsign, labelX, lineY);
+    lineY += lineHeight;
+
+    ctx.fillText(altitudeLabel, labelX, lineY);
+    lineY += lineHeight;
+
     ctx.fillText(
-      "R" + Math.floor(riskLevel).toString(),
+      "G" + Math.floor(aircraft.vector.groundSpeed / 10).toString(),
       labelX,
-      labelY + 45,
+      lineY
     );
+    ctx.fillText(
+      aircraft.destinationIcao.length >= 4
+        ? aircraft.destinationIcao.slice(-3)
+        : aircraft.destinationIcao,
+      labelX + 40,
+      lineY
+    );
+    lineY += lineHeight;
+
+    ctx.fillStyle = riskColor;
+    ctx.fillText("R" + Math.floor(riskLevel).toString(), labelX, lineY);
+    lineY += lineHeight;
+
+    if (setting.aircraftType && aircraft.model) {
+      ctx.fillStyle = "white";
+      const modelDisplay =
+        aircraft.model.length > 6 ? aircraft.model.slice(0, 6) : aircraft.model;
+      ctx.fillText(modelDisplay, labelX, lineY);
+      lineY += lineHeight;
+    }
+
+    if (setting.eta && aircraft.eta) {
+      const etaFormatted = formatEtaToHhMm(aircraft.eta);
+      if (etaFormatted) {
+        ctx.fillStyle = "white";
+        ctx.fillText(etaFormatted, labelX, lineY);
+        lineY += lineHeight;
+      }
+    }
+
+    if (setting.squawk) {
+      ctx.fillStyle = "white";
+      const squawkDisplay =
+        (aircraft as Aircraft & { squawk?: string }).squawk ?? "---";
+      ctx.fillText(squawkDisplay, labelX, lineY);
+    }
   }
 
-  private static drawLabelLiine(ctx: CanvasRenderingContext2D, aircraftPosition: { x: number; y: number }, labelPosition: { x: number; y: number }) {
+  private static drawLabelLiine(
+    ctx: CanvasRenderingContext2D,
+    aircraftPosition: { x: number; y: number },
+    labelPosition: { x: number; y: number }
+  ) {
     const labelX: number = aircraftPosition.x + labelPosition.x;
     const labelY: number = aircraftPosition.y - labelPosition.y;
-    const labelDistance: number = Math.sqrt(Math.pow(labelPosition.x, 2) + Math.pow(labelPosition.y, 2));
+    const labelDistance: number = Math.sqrt(
+      Math.pow(labelPosition.x, 2) + Math.pow(labelPosition.y, 2)
+    );
     const sin = labelPosition.y / labelDistance;
     const cos = labelPosition.x / labelDistance;
 
     ctx.beginPath();
-    ctx.moveTo(aircraftPosition.x + (10 * cos), aircraftPosition.y - (10 * sin));
+    ctx.moveTo(aircraftPosition.x + 10 * cos, aircraftPosition.y - 10 * sin);
     ctx.lineTo(labelX - 5, labelY + 15);
     ctx.strokeStyle = "white";
     ctx.stroke();

--- a/Frontend/utility/aircraft/drawAircraft.ts
+++ b/Frontend/utility/aircraft/drawAircraft.ts
@@ -4,16 +4,7 @@ import { GLOBAL_SETTINGS } from "../globals/settings";
 import { Aircraft } from "./aircraftClass";
 import { DisplayRange } from "@/context/displayRangeContext";
 import type { DataBlockDisplaySetting } from "@/context/dataBlockDisplaySettingContext";
-
-function formatEtaToHhMm(eta: string): string {
-  try {
-    const date = new Date(eta);
-    if (Number.isNaN(date.getTime())) return "";
-    return date.toTimeString().slice(0, 5);
-  } catch {
-    return "";
-  }
-}
+import { formatEtaToUtcHhMm } from "./formatEtaUtc";
 
 /**
  * Class to draw aircraft on the canvas
@@ -154,7 +145,7 @@ class DrawAircraft {
     }
 
     if (setting.eta && aircraft.eta) {
-      const etaFormatted = formatEtaToHhMm(aircraft.eta);
+      const etaFormatted = formatEtaToUtcHhMm(aircraft.eta);
       if (etaFormatted) {
         ctx.fillStyle = "white";
         ctx.fillText(etaFormatted, labelX, lineY);

--- a/Frontend/utility/aircraft/formatEtaUtc.test.ts
+++ b/Frontend/utility/aircraft/formatEtaUtc.test.ts
@@ -1,0 +1,22 @@
+import { formatEtaToUtcHhMm } from "./formatEtaUtc";
+
+describe("formatEtaToUtcHhMm", () => {
+  it("formats Zulu ISO as UTC HH:mm", () => {
+    expect(formatEtaToUtcHhMm("2024-09-11T12:55:00Z")).toBe("12:55");
+  });
+
+  it("uses UTC for offset timestamps (same instant)", () => {
+    expect(formatEtaToUtcHhMm("2024-09-11T15:55:00+03:00")).toBe("12:55");
+  });
+
+  it("pads hours and minutes", () => {
+    expect(formatEtaToUtcHhMm("2024-01-01T03:05:00Z")).toBe("03:05");
+    expect(formatEtaToUtcHhMm("2024-01-01T00:00:00Z")).toBe("00:00");
+  });
+
+  it("returns empty for blank or invalid", () => {
+    expect(formatEtaToUtcHhMm("")).toBe("");
+    expect(formatEtaToUtcHhMm("   ")).toBe("");
+    expect(formatEtaToUtcHhMm("not-a-date")).toBe("");
+  });
+});

--- a/Frontend/utility/aircraft/formatEtaUtc.ts
+++ b/Frontend/utility/aircraft/formatEtaUtc.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats API ETA (ISO 8601 instant, typically with Z) as HH:mm in UTC so the
+ * data block matches backend semantics and is independent of browser timezone.
+ */
+export function formatEtaToUtcHhMm(eta: string): string {
+  try {
+    const trimmed = eta.trim();
+    if (!trimmed) return "";
+    const date = new Date(trimmed);
+    if (Number.isNaN(date.getTime())) return "";
+    const h = date.getUTCHours();
+    const m = date.getUTCMinutes();
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+  } catch {
+    return "";
+  }
+}

--- a/Frontend/utility/api/location.ts
+++ b/Frontend/utility/api/location.ts
@@ -14,6 +14,7 @@ export interface AircraftLocationDto {
   originIcao: string;
   destinationIata: string;
   destinationIcao: string;
+  /** ISO 8601 instant (e.g. …Z). Data block shows UTC HH:mm. */
   eta: string;
   riskLevel: number;
 }

--- a/spec/20260318-data-block-display-items/spec.md
+++ b/spec/20260318-data-block-display-items/spec.md
@@ -1,0 +1,181 @@
+# データブロック（ラベル）表示項目追加（2-3）
+
+## メタデータ
+
+- **Status**: Draft
+- **Date**: 2026-03-18
+- **関連 Issue**: [#51](https://github.com/Futty93/Horus/issues/51)
+- **親 spec**: [spec/spec.md Phase 2-3](../../spec/spec.md)
+
+## 概要
+
+レーダー上のデータブロック（航空機ラベル）に表示する項目を選択式で拡張する。スクオーク・機種・ETA などをユーザーが設定 UI で選択し、有効な項目のみをラベルに表示する。管制業務で必要な情報を必要に応じて表示・非表示できるようにする。
+
+---
+
+## 背景・課題
+
+### 現状
+
+| 項目 | 状態 |
+|------|------|
+| **描画場所** | `Frontend/utility/aircraft/drawAircraft.ts` の `drawAircraftLabel` |
+| **固定表示項目** | コールサイン、高度（指示↑/↓現在）、対地速度（G）、目的地（ICAO 下3桁）、危険度（R） |
+| **データソース** | `AircraftLocationDto` → `location.ts` の `mapDtoToAircraft` → `Aircraft` クラス |
+| **利用可能データ** | `model`（機種）, `eta`（ISO 8601）, `destinationIcao` は既に取得済み |
+| **スクオーク** | 未実装。spec 3-1（Issue #55）でバックエンドに追加予定 |
+
+現在は表示項目が固定で、機種・ETA などは API から取得しているがラベルには出していない。表示項目の ON/OFF や追加の設定 UI も存在しない。
+
+### 課題（Problem Statement）
+
+- 機種・ETA といった管制上有用な情報がラベルに表示されない
+- ユーザーが表示項目を選べない（例: 機種が不要な場合は非表示にしたい）
+- 将来的なスクオーク表示（3-1）を見据えた拡張性がない
+
+### なぜ今か（Motivation）
+
+- Phase 2「レーダー表示の強化」の一環。難易度 ★☆☆ で実装コストが低い
+- レンジリング（2-2）と同様、Context + 設定 UI のパターンで一貫した拡張が可能
+- 3-1（スクオーク）完了前でも、表示スロットと設定 UI を先に入れておけば後から値だけ接続できる
+
+---
+
+## 詳細調査結果
+
+### ラベル描画の現状レイアウト
+
+```
+labelX, labelY+0   : callsign
+labelX, labelY+15   : altitudeLabel（指示高度 ↑/↓ 現在高度）
+labelX, labelY+30   : "G" + groundspeed/10
+labelX+40, labelY+30: destinationIcao 下3桁
+labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
+```
+
+### API / Aircraft で利用可能な項目
+
+| 表示候補 | Aircraft プロパティ | DTO フィールド | 備考 |
+|----------|---------------------|-----------------|------|
+| 機種 | `model` | `model` | B738, B777 等。Commercial 以外は type 由来 |
+| ETA | `eta` | `eta` | ISO 8601。Commercial のみ。空文字の場合あり |
+| スクオーク | 未存在 | 未存在 | 3-1 で追加予定。当面は "---" または非表示 |
+| コールサイン | `callsign` | `callsign` | 既存・常時表示を維持 |
+| 高度・速度・目的地・危険度 | 既存 | 既存 | 既存のまま。表示 ON/OFF を追加するかは別途検討 |
+
+### 参照実装
+
+- **rangeRingsSettingContext**: `enabled`, `intervalNm` を持ち、設定パネルで変更。`routeRenderer.drawRangeRings` に渡して描画を制御
+- 同様に `DataBlockDisplaySetting` を Context 化し、`drawAircraftLabel` に渡す構成とする
+
+---
+
+## 方針
+
+### 決定方針（Decision）
+
+**フロントエンド中心で完結。** バックエンドの変更は 3-1（スクオーク）で別途実施。
+
+1. **表示項目の設定**
+   - `DataBlockDisplaySetting` 型: `squawk`, `aircraftType`, `eta` を boolean で ON/OFF
+   - デフォルト: 機種・ETA を ON、スクオークは OFF（値が無いため）
+   - 3-1 完了後、スクオーク ON で 4 桁表示。OFF または値無し時は表示しない
+
+2. **描画ロジック**
+   - `drawAircraftLabel` に `DataBlockDisplaySetting` を渡す
+   - 各項目を設定に応じて描画。行の順序・レイアウトは既存に合わせて追加
+   - ETA: ISO 8601 を `HH:mm` 等にフォーマット。空の場合は表示しない
+   - 機種: `model` をそのまま表示（長い場合は省略検討）
+   - スクオーク: 値があれば 4 桁、なければ "---" または表示行自体をスキップ（設定による）
+
+3. **設定 UI**
+   - チェックボックスで「スクオーク」「機種」「ETA」の ON/OFF
+   - DisplayRangeSetting や RangeRingsSetting と同様のパネルに配置（Operator / Controller）
+   - スクオークは「3-1 完了後に有効化」と明記するか、最初はグレーアウトでも可
+
+### 検討した他案（Alternatives Considered）
+
+- **案 A**: 既存項目（高度・速度・目的地・危険度）も ON/OFF 対象にする。採用しなかった理由: 必須情報が消えると混乱する。まずは追加項目のみ選択式にして様子見
+- **案 B**: スクオークを 2-3 スコープ外にする。採用しなかった理由: 表示スロットと設定 UI を先に入れておけば 3-1 との統合が容易。プレースホルダ表示で十分
+
+### トレードオフ（Trade-offs）
+
+- **メリット**: 既存の Context/設定パネル構成を流用でき、変更が局所的
+- **デメリット / 受容する制約**: スクオークは 3-1 完了まで実質未使用。ラベルが長くなりレーダー上で重なる可能性は、フォントサイズやレイアウト調整で対応
+
+---
+
+## 完了条件（Success Criteria）
+
+- [ ] 表示項目の設定 UI が Operator / Controller に存在する（スクオーク・機種・ETA の ON/OFF）
+- [ ] 機種（model）が ON のときラベルに表示される
+- [ ] ETA が ON かつ値があるとき、フォーマット済み時刻がラベルに表示される
+- [ ] スクオークが ON のとき、値があれば 4 桁表示、なければ "---" または非表示（3-1 前は常に無し想定）
+- [ ] 設定の変更がレンダリングに即時反映される
+- [ ] 既存のコールサイン・高度・速度・目的地・危険度の表示に影響がない
+
+---
+
+## 影響範囲
+
+- **Frontend/utility/aircraft/drawAircraft.ts**: `drawAircraftLabel` に `DataBlockDisplaySetting` を渡し、条件付き描画を追加
+- **Frontend/context/**: `DataBlockDisplaySettingContext` 新規作成（または既存設定 Context に統合）
+- **Frontend/components/**: データブロック表示設定用 UI（チェックボックス群）を新規または既存パネルに追加
+- **Frontend/components/radarCanvas.tsx**: 設定値を `DrawAircraft.drawAircraft` に渡す
+- **Frontend/utility/aircraft/aircraftClass.ts**: スクオーク用プロパティは 3-1 で追加。本 spec では不要
+- **Backend**: 変更なし（3-1 で AircraftLocationDto に squawk 追加予定）
+
+---
+
+## 実装計画
+
+### Phase 1: 設定基盤と機種・ETA（Must-have）
+
+1. **DataBlockDisplaySetting 型と Context**
+   - `{ squawk: boolean; aircraftType: boolean; eta: boolean }`
+   - デフォルト: `aircraftType: true`, `eta: true`, `squawk: false`
+   - `DataBlockDisplaySettingContext` で Provider 提供
+
+2. **drawAircraftLabel の拡張**
+   - 引数に `DataBlockDisplaySetting` を追加
+   - `aircraftType` ON 時: `model` を適切な行に描画
+   - `eta` ON 時: `eta` を `HH:mm` 等にフォーマットして描画（空はスキップ）
+   - レイアウトは既存の下に追記、または行間を調整
+
+3. **設定 UI**
+   - チェックボックス 3 つ（スクオーク・機種・ETA）
+   - Operator / Controller の右パネルに配置
+   - RangeRingsSetting 付近または DisplayRangeSetting 付近
+
+### Phase 2: スクオーク表示対応（3-1 連携）
+
+- 3-1 で `AircraftLocationDto` に `squawk` 追加後
+- `Aircraft` に squawk プロパティ追加、`mapDtoToAircraft` でマッピング
+- `drawAircraftLabel` で squawk ON かつ値ありなら 4 桁表示
+
+---
+
+## 検証
+
+- [ ] `npm run build` が通る
+- [ ] Operator / Controller 画面で設定 UI が表示され、チェックで表示 ON/OFF が切り替わる
+- [ ] 機種・ETA がラベルに表示される（データがある場合）
+- [ ] 既存の表示（コールサイン・高度・速度・目的地・危険度）が従来どおり動作する
+
+---
+
+## 未解決事項（Unresolved Questions）
+
+- ラベル行の最大数・レイアウト（機種名が長い場合の省略ルール）
+- ETA のフォーマット（`HH:mm` vs `HH:mm:ss` vs 日付を含めるか）
+- 設定 UI の配置（新規パネル vs 既存 DisplayRangeSetting への統合）
+
+---
+
+## 関連ドキュメント
+
+- [spec/spec.md Phase 2](../../spec.md)
+- [Issue #51](https://github.com/Futty93/Horus/issues/51)
+- [Issue #55（スクオーク 3-1）](https://github.com/Futty93/Horus/issues/55)
+- [spec/20260318-range-rings-display — 参照実装](../20260318-range-rings-display/spec.md)
+- [Frontend/utility/aircraft/drawAircraft.ts](../../Frontend/utility/aircraft/drawAircraft.ts)

--- a/spec/20260318-data-block-display-items/spec.md
+++ b/spec/20260318-data-block-display-items/spec.md
@@ -59,7 +59,7 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 | 表示候補 | Aircraft プロパティ | DTO フィールド | 備考 |
 |----------|---------------------|-----------------|------|
 | 機種 | `model` | `model` | B738, B777 等。Commercial 以外は type 由来 |
-| ETA | `eta` | `eta` | ISO 8601。Commercial のみ。空文字の場合あり |
+| ETA | `eta` | `eta` | ISO 8601（UTC インスタント、例 `...Z`）。Commercial のみ。空文字の場合あり |
 | スクオーク | 未存在 | 未存在 | 3-1 で追加予定。当面は "---" または非表示 |
 | コールサイン | `callsign` | `callsign` | 既存・常時表示を維持 |
 | 高度・速度・目的地・危険度 | 既存 | 既存 | 既存のまま。表示 ON/OFF を追加するかは別途検討 |
@@ -85,7 +85,7 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 2. **描画ロジック**
    - `drawAircraftLabel` に `DataBlockDisplaySetting` を渡す
    - 各項目を設定に応じて描画。行の順序・レイアウトは既存に合わせて追加
-   - ETA: ISO 8601 を `HH:mm` 等にフォーマット。空の場合は表示しない
+   - ETA: ISO 8601 インスタントを **UTC（Zulu）の `HH:mm`** にフォーマット（ブラウザのローカルタイムゾーンには依存しない）。空・パース不能の場合は表示しない
    - 機種: `model` をそのまま表示（長い場合は省略検討）
    - スクオーク: 値があれば 4 桁、なければ "---" または表示行自体をスキップ（設定による）
 
@@ -104,6 +104,15 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 
 - **メリット**: 既存の Context/設定パネル構成を流用でき、変更が局所的
 - **デメリット / 受容する制約**: スクオークは 3-1 完了まで実質未使用。ラベルが長くなりレーダー上で重なる可能性は、フォントサイズやレイアウト調整で対応
+
+### ETA 表示のタイムゾーン（決定）
+
+| 項目 | 決定内容 |
+|------|-----------|
+| **基準** | **UTC（Zulu）**。バックエンドの `eta` が ISO 8601 で表す同一瞬間の「協定世界時での時・分」を表示する。 |
+| **理由** | API は `Z` 付き等の UTC 意味を持つ文字列を返す（`CommercialAircraft` コメント・Create 例に準拠）。ATC では Zulu 表示が一般的で、ワークステーションのローカル TZ に依存させない方が訓練・再現性に有利。 |
+| **形式** | `HH:mm`（24 時間、先頭ゼロ埋め）。秒は付けない。 |
+| **UTC / JST 切替** | [#91](https://github.com/Futty93/Horus/issues/91)（`good first issue`）で対応予定。**データブロック表示設定**（既存のスクオーク・機種・ETA と同じパネル想定）に **UTC / JST** の選択項目を追加し、ETA のフォーマット基準を切り替える。現行リリースは UTC 固定。 |
 
 ---
 
@@ -141,7 +150,7 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 2. **drawAircraftLabel の拡張**
    - 引数に `DataBlockDisplaySetting` を追加
    - `aircraftType` ON 時: `model` を適切な行に描画
-   - `eta` ON 時: `eta` を `HH:mm` 等にフォーマットして描画（空はスキップ）
+   - `eta` ON 時: `eta` を UTC の `HH:mm` にフォーマットして描画（空・無効はスキップ）。実装は `formatEtaToUtcHhMm`（`Frontend/utility/aircraft/formatEtaUtc.ts`）
    - レイアウトは既存の下に追記、または行間を調整
 
 3. **設定 UI**
@@ -169,7 +178,8 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 ## 未解決事項（Unresolved Questions）
 
 - ラベル行の最大数・レイアウト（機種名が長い場合の省略ルール）
-- ETA のフォーマット（`HH:mm` vs `HH:mm:ss` vs 日付を含めるか）
+
+**解決済み**: ETA は UTC の `HH:mm`（上記「ETA 表示のタイムゾーン」参照）。日付はラベルに含めない。
 
 ---
 
@@ -180,3 +190,4 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 - [Issue #55（スクオーク 3-1）](https://github.com/Futty93/Horus/issues/55)
 - [spec/20260318-range-rings-display — 参照実装](../20260318-range-rings-display/spec.md)
 - [Frontend/utility/aircraft/drawAircraft.ts](../../Frontend/utility/aircraft/drawAircraft.ts)
+- [Frontend/utility/aircraft/formatEtaUtc.ts](../../Frontend/utility/aircraft/formatEtaUtc.ts)

--- a/spec/20260318-data-block-display-items/spec.md
+++ b/spec/20260318-data-block-display-items/spec.md
@@ -45,11 +45,12 @@
 
 ### ラベル描画の現状レイアウト
 
+- 各項目は縦並び。**グランドスピード（G）と目的地は同一行で横並び**（labelX と labelX+40）。
+
 ```
-labelX, labelY+0   : callsign
+labelX, labelY+0    : callsign
 labelX, labelY+15   : altitudeLabel（指示高度 ↑/↓ 現在高度）
-labelX, labelY+30   : "G" + groundspeed/10
-labelX+40, labelY+30: destinationIcao 下3桁
+labelX, labelY+30   : "G" + groundspeed/10  |  labelX+40, labelY+30: destinationIcao 下3桁
 labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 ```
 
@@ -90,7 +91,8 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 
 3. **設定 UI**
    - チェックボックスで「スクオーク」「機種」「ETA」の ON/OFF
-   - DisplayRangeSetting や RangeRingsSetting と同様のパネルに配置（Operator / Controller）
+   - **コラプシブル**: 滅多に変更しないため、デフォルトは折りたたみでコンパクト表示（「データブロック」と現在有効な項目のサマリを表示）。クリックで展開し、チェックボックスで設定変更可能
+   - Operator / Controller の右パネルに配置（RangeRingsSetting 等と同列）
    - スクオークは「3-1 完了後に有効化」と明記するか、最初はグレーアウトでも可
 
 ### 検討した他案（Alternatives Considered）
@@ -144,8 +146,8 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 
 3. **設定 UI**
    - チェックボックス 3 つ（スクオーク・機種・ETA）
-   - Operator / Controller の右パネルに配置
-   - RangeRingsSetting 付近または DisplayRangeSetting 付近
+   - コラプシブル表示（折りたたみ時にサマリ表示）
+   - Operator / Controller の右パネルに配置（RangeRingsSetting 付近）
 
 ### Phase 2: スクオーク表示対応（3-1 連携）
 
@@ -168,7 +170,6 @@ labelX, labelY+45   : "R" + riskLevel（色分け: 白/黄/赤）
 
 - ラベル行の最大数・レイアウト（機種名が長い場合の省略ルール）
 - ETA のフォーマット（`HH:mm` vs `HH:mm:ss` vs 日付を含めるか）
-- 設定 UI の配置（新規パネル vs 既存 DisplayRangeSetting への統合）
 
 ---
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -34,7 +34,7 @@
 |---|--------|--------|--------|-------|------|
 | 2-1 | 履歴ドット（過去位置の軌跡）表示 | 🔴 | ★☆☆ | [#49](https://github.com/Futty93/Horus/issues/49) | Canvas に過去 N 点を保持して描画 |
 | 2-2 | レンジリング（距離環）表示 | 🔴 | ★☆☆ | [#50](https://github.com/Futty93/Horus/issues/50) | 中心から同心円。表示 NM 数は設定可能に → [spec/20260318-range-rings-display](spec/20260318-range-rings-display/spec.md) |
-| 2-3 | データブロック（ラベル）に表示項目を追加 | 🟡 | ★☆☆ | [#51](https://github.com/Futty93/Horus/issues/51) | スクオーク・機種・ETA など選択式 |
+| 2-3 | データブロック（ラベル）に表示項目を追加 | 🟡 | ★☆☆ | [#51](https://github.com/Futty93/Horus/issues/51) | スクオーク・機種・ETA など選択式 → [spec/20260318-data-block-display-items](20260318-data-block-display-items/spec.md) |
 | 2-4 | 速度ベクトル線の長さ（時間）調整 | 🟡 | ★☆☆ | [#52](https://github.com/Futty93/Horus/issues/52) | 設定パネルに追加 |
 | 2-5 | セクター境界線の表示 | 🟡 | ★★☆ | [#53](https://github.com/Futty93/Horus/issues/53) | 担当空域を JSON で定義して描画 |
 | 2-6 | 指示メモをレーダーラベル隣に表示 | 🟡 | ★★☆ | [#54](https://github.com/Futty93/Horus/issues/54) | spec 20260308-ui-ux-improvement の Out of Scope 項目 |


### PR DESCRIPTION
## 概要

データブロック（ラベル）の表示項目（機種・ETA・スクオーク）を Context で制御し、設定 UI を折りたたみ可能に。共通 `CollapsiblePanel` を導入し、担当セクター・表示範囲・レンジリングを `RadarViewSetting` に統合。spec を更新。

## 実装の意図

- Phase 2-3（Issue #51）に沿い、追加表示項目を ON/OFF できるようにする
- 右パネルの縦スペースを節約するため、設定をコラプシブル化
- レーダー表示まわりの設定を意味的にまとめ、DRY にする

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [x] ドキュメント
- [ ] その他

## 変更内容

- `DataBlockDisplaySetting` / `DataBlockDisplaySettingContext`：`drawAircraftLabel` に機種・ETA・スクオーク（プレースホルダ）を条件付き描画
- `Frontend/components/ui/collapsiblePanel.tsx`：折りたたみパネル共通化（`aria-expanded` / `aria-controls`）
- `RadarViewSetting`：SectorSelector + DisplayRangeSetting + RangeRingsSetting を1パネルに統合
- `SectorSelector`：`embedded` / 制御モード（`value` + `onChange`）、`sectorCenterCoordinates` を export
- `DisplayRangeSetting` / `RangeRingsSetting`：`embedded` 対応、表示範囲入力を controlled に
- `RouteInfoDisplaySetting`：`CollapsiblePanel` 利用
- Operator / Controller の設定エリアを上記構成に更新
- `spec/20260318-data-block-display-items/spec.md`：レイアウト（G と目的地の横並び）、コラプシブル UI を追記

## テスト

- [x] 該当なし（既存ロジックの変更のみ）
- [ ] テストを追加した（`Backend/src/test/` または `Frontend/` のテスト）
- [ ] テストは未追加（理由を備考に記載）

## 関連 issue / 実装計画

- Issue #51
- spec [20260318-data-block-display-items](spec/20260318-data-block-display-items/spec.md)

## 動作確認

- [ ] バックエンドのテストが通る（`./gradlew test`）
- [x] フロントエンドのビルドが通る（`npm run build`）
- [ ] 手動で動作確認した

## 備考

- スクオークは 3-1 完了までデータなし想定
- 手動確認はレビュアーまたはマージ前に実施推奨
