### PR TITLE
feat: レーダー速度ベクトルの予測時間を調整可能にする

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -117,6 +117,7 @@ Frontend/
 │   ├── flight-plan-setup/ # フライトプラン設定用（OdGroupSection, AtsRouteSearch）
 │   ├── sectorSelector.tsx # セクター選択
 │   ├── displayRangeSetting.tsx # 表示範囲設定（ビジュアルレンジバー）
+│   ├── velocityVectorLookaheadSetting.tsx # 速度ベクトル予測時間（スライダー、0.5～10 分）
 │   └── ...
 ├── context/              # React Context定義
 ├── utility/             # ユーティリティ関数
@@ -144,6 +145,7 @@ Frontend/
 **主な機能**:
 
 - 航空機の位置表示
+- **速度ベクトル線**（針路方向の白線）の長さは、地速に対し **速度ベクトル予測時間（分）** に比例。`レーダー表示` パネルのスライダーで **0.5～10 分・0.5 分刻み**（既定 1 分）。表示のみでシミュレーション計算は変更しない（[spec/20260404-velocity-vector-line-duration/spec.md](../spec/20260404-velocity-vector-line-duration/spec.md)）。値は `localStorage` に保存し、Controller / Operator で共有。
 - 経路情報の表示
 - マウスインタラクション
 - ズーム/パン機能
@@ -210,7 +212,8 @@ React Context APIを使用して、以下の状態を管理しています：
 3. **経路情報表示設定** (RouteInfoDisplaySettingContext)
 4. **データブロック表示設定** (DataBlockDisplaySettingContext) — スクオーク・機種・ETA・**管制クリアランスメモ行**の表示 ON/OFF（**管制メモ行のトグルは Controller 画面のみ**。Operator では該当チェックボックスを出さない）
 5. **Fix選択モード** (SelectFixModeContext)
-6. **選択航空機** (SelectedAircraftContext) — callsign と `instructedVector`（パイロット操縦目標: altitude, groundSpeed, heading）
+6. **速度ベクトル予測時間** (VelocityVectorLookaheadContext) — レーダー上の速度ベクトル線の長さに対応する時間（分）。Controller / Operator 共通、`localStorage` 永続化
+7. **選択航空機** (SelectedAircraftContext) — callsign と `instructedVector`（パイロット操縦目標: altitude, groundSpeed, heading）
 
 ## API通信
 

--- a/Frontend/app/controller/page.tsx
+++ b/Frontend/app/controller/page.tsx
@@ -4,6 +4,7 @@ import { RouteInfoDisplaySettingProvider } from "@/context/routeInfoDisplaySetti
 import RouteInfoDisplaySetting from "@/components/routeInfoDisplaySetting";
 import { CenterCoordinateProvider } from "@/context/centerCoordinateContext";
 import { DisplayRangeProvider } from "@/context/displayRangeContext";
+import { VelocityVectorLookaheadProvider } from "@/context/velocityVectorLookaheadContext";
 import { RangeRingsSettingProvider } from "@/context/rangeRingsSettingContext";
 import RadarViewSetting from "@/components/radarViewSetting";
 import { DataBlockDisplaySettingProvider } from "@/context/dataBlockDisplaySettingContext";
@@ -25,38 +26,40 @@ export default function ControllerPage() {
     <RouteInfoDisplaySettingProvider>
       <CenterCoordinateProvider>
         <DisplayRangeProvider>
-          <RangeRingsSettingProvider>
-            <DataBlockDisplaySettingProvider>
-              <SelectFixModeProvider>
-                <SelectedAircraftProvider>
-                  <div className="flex h-screen w-full">
-                    <div className="flex w-full">
-                      <RadarCanvas />
-                      <div
-                        className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
+          <VelocityVectorLookaheadProvider>
+            <RangeRingsSettingProvider>
+              <DataBlockDisplaySettingProvider>
+                <SelectFixModeProvider>
+                  <SelectedAircraftProvider>
+                    <div className="flex h-screen w-full">
+                      <div className="flex w-full">
+                        <RadarCanvas />
+                        <div
+                          className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
                               p-4 flex flex-col justify-between min-w-80 max-w-80
                               h-full overflow-y-auto overflow-x-hidden
                               scrollbar-thin scrollbar-track-atc scrollbar-thumb-atc"
-                      >
-                        <div className="flex-1 space-y-4 min-h-0">
-                          <SelectedCallsignDisplay variant="controller" />
-                          <FlightPlanDisplay />
-                          <InstructionMemo />
-                        </div>
-                        <div id="settingArea" className="mt-4 space-y-4">
-                          <RouteInfoDisplaySetting />
-                          <div className="flex flex-col space-y-3">
-                            <RadarViewSetting />
-                            <DataBlockDisplaySetting />
+                        >
+                          <div className="flex-1 space-y-4 min-h-0">
+                            <SelectedCallsignDisplay variant="controller" />
+                            <FlightPlanDisplay />
+                            <InstructionMemo />
+                          </div>
+                          <div id="settingArea" className="mt-4 space-y-4">
+                            <RouteInfoDisplaySetting />
+                            <div className="flex flex-col space-y-3">
+                              <RadarViewSetting />
+                              <DataBlockDisplaySetting />
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                </SelectedAircraftProvider>
-              </SelectFixModeProvider>
-            </DataBlockDisplaySettingProvider>
-          </RangeRingsSettingProvider>
+                  </SelectedAircraftProvider>
+                </SelectFixModeProvider>
+              </DataBlockDisplaySettingProvider>
+            </RangeRingsSettingProvider>
+          </VelocityVectorLookaheadProvider>
         </DisplayRangeProvider>
       </CenterCoordinateProvider>
     </RouteInfoDisplaySettingProvider>

--- a/Frontend/app/operator/page.tsx
+++ b/Frontend/app/operator/page.tsx
@@ -4,6 +4,7 @@ import { RouteInfoDisplaySettingProvider } from "@/context/routeInfoDisplaySetti
 import RouteInfoDisplaySetting from "@/components/routeInfoDisplaySetting";
 import { CenterCoordinateProvider } from "@/context/centerCoordinateContext";
 import { DisplayRangeProvider } from "@/context/displayRangeContext";
+import { VelocityVectorLookaheadProvider } from "@/context/velocityVectorLookaheadContext";
 import { RangeRingsSettingProvider } from "@/context/rangeRingsSettingContext";
 import RadarViewSetting from "@/components/radarViewSetting";
 import { DataBlockDisplaySettingProvider } from "@/context/dataBlockDisplaySettingContext";
@@ -26,44 +27,46 @@ export default function OperatorPage() {
     <RouteInfoDisplaySettingProvider>
       <CenterCoordinateProvider>
         <DisplayRangeProvider>
-          <RangeRingsSettingProvider>
-            <DataBlockDisplaySettingProvider>
-              <SelectFixModeProvider>
-                <SelectedAircraftProvider>
-                  <div className="flex h-screen w-full overflow-hidden">
-                    <div className="flex w-full h-full">
-                      <RadarCanvas />
-                      <div
-                        className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
+          <VelocityVectorLookaheadProvider>
+            <RangeRingsSettingProvider>
+              <DataBlockDisplaySettingProvider>
+                <SelectFixModeProvider>
+                  <SelectedAircraftProvider>
+                    <div className="flex h-screen w-full overflow-hidden">
+                      <div className="flex w-full h-full">
+                        <RadarCanvas />
+                        <div
+                          className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
                                   p-3 flex flex-col min-w-80 max-w-80
                                   h-full overflow-y-auto overflow-x-hidden
                                   scrollbar-thin scrollbar-track-atc scrollbar-thumb-atc"
-                      >
-                        <SelectedCallsignDisplay variant="operator" />
+                        >
+                          <SelectedCallsignDisplay variant="operator" />
 
-                        {/* Scrollable Content */}
-                        <div className="flex-1 space-y-4 min-h-0">
-                          <ControlAircraft />
-                          <SelectFixMode />
-                          <FlightPlanControl />
+                          {/* Scrollable Content */}
+                          <div className="flex-1 space-y-4 min-h-0">
+                            <ControlAircraft />
+                            <SelectFixMode />
+                            <FlightPlanControl />
 
-                          {/* Settings Area */}
-                          <div className="space-y-3">
-                            <RouteInfoDisplaySetting />
-                            <RadarViewSetting />
-                            <DataBlockDisplaySetting variant="operator" />
+                            {/* Settings Area */}
+                            <div className="space-y-3">
+                              <RouteInfoDisplaySetting />
+                              <RadarViewSetting />
+                              <DataBlockDisplaySetting variant="operator" />
 
-                            {/* Control Buttons */}
-                            <SimulationControlButtons />
+                              {/* Control Buttons */}
+                              <SimulationControlButtons />
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                </SelectedAircraftProvider>
-              </SelectFixModeProvider>
-            </DataBlockDisplaySettingProvider>
-          </RangeRingsSettingProvider>
+                  </SelectedAircraftProvider>
+                </SelectFixModeProvider>
+              </DataBlockDisplaySettingProvider>
+            </RangeRingsSettingProvider>
+          </VelocityVectorLookaheadProvider>
         </DisplayRangeProvider>
       </CenterCoordinateProvider>
     </RouteInfoDisplaySettingProvider>

--- a/Frontend/components/radarCanvas.tsx
+++ b/Frontend/components/radarCanvas.tsx
@@ -13,6 +13,7 @@ import { DrawAircraft } from "@/utility/aircraft/drawAircraft";
 import { useRouteInfoDisplaySetting } from "@/context/routeInfoDisplaySettingContext";
 import { useCenterCoordinate } from "@/context/centerCoordinateContext";
 import { useDisplayRange } from "@/context/displayRangeContext";
+import { useVelocityVectorLookahead } from "@/context/velocityVectorLookaheadContext";
 import { useRangeRingsSetting } from "@/context/rangeRingsSettingContext";
 import {
   useDataBlockDisplaySetting,
@@ -49,6 +50,8 @@ const RadarCanvas: React.FC = () => {
   const centerCoordinateRef = useRef(centerCoordinate);
   const { displayRange } = useDisplayRange();
   const displayRangeRef = useRef(displayRange);
+  const { durationMinutes } = useVelocityVectorLookahead();
+  const velocityVectorDurationRef = useRef(durationMinutes);
   const { rangeRingsSetting } = useRangeRingsSetting();
   const rangeRingsSettingRef = useRef(rangeRingsSetting);
   const { dataBlockDisplaySetting } = useDataBlockDisplaySetting();
@@ -78,6 +81,7 @@ const RadarCanvas: React.FC = () => {
   isDisplayingRef.current = isDisplaying;
   centerCoordinateRef.current = centerCoordinate;
   displayRangeRef.current = displayRange;
+  velocityVectorDurationRef.current = durationMinutes;
   rangeRingsSettingRef.current = rangeRingsSetting;
   dataBlockDisplaySettingRef.current = dataBlockRadarSetting;
   isSelectFixModeRef.current = isSelectFixMode;
@@ -222,7 +226,8 @@ const RadarCanvas: React.FC = () => {
         aircraft,
         displayRangeRef.current,
         dataBlockDisplaySettingRef.current,
-        controllerClearanceAltitudeRowRef.current
+        controllerClearanceAltitudeRowRef.current,
+        velocityVectorDurationRef.current
       );
     });
   };

--- a/Frontend/components/radarViewSetting.tsx
+++ b/Frontend/components/radarViewSetting.tsx
@@ -4,18 +4,21 @@ import CollapsiblePanel from "@/components/ui/collapsiblePanel";
 import SectorSelector from "@/components/sectorSelector";
 import DisplayRangeSetting from "@/components/displayRangeSetting";
 import RangeRingsSetting from "@/components/rangeRingsSetting";
+import VelocityVectorLookaheadSetting from "@/components/velocityVectorLookaheadSetting";
 import { useDisplayRange } from "@/context/displayRangeContext";
 import { useRangeRingsSetting } from "@/context/rangeRingsSettingContext";
+import { useVelocityVectorLookahead } from "@/context/velocityVectorLookaheadContext";
 
 const RadarViewSetting = () => {
   const [selectedSector, setSelectedSector] = useState("T09");
   const { displayRange } = useDisplayRange();
   const { rangeRingsSetting } = useRangeRingsSetting();
+  const { durationMinutes } = useVelocityVectorLookahead();
 
   const rangeSummary = rangeRingsSetting.enabled
     ? `${rangeRingsSetting.intervalNm}NM`
     : "オフ";
-  const summary = `${selectedSector}, ${displayRange.range}km, レンジ${rangeSummary}`;
+  const summary = `${selectedSector}, ${displayRange.range}km, レンジ${rangeSummary}, 予測時間${durationMinutes}分`;
 
   return (
     <CollapsiblePanel title="レーダー表示" summary={summary}>
@@ -26,6 +29,7 @@ const RadarViewSetting = () => {
           onChange={setSelectedSector}
         />
         <DisplayRangeSetting embedded />
+        <VelocityVectorLookaheadSetting embedded />
         <RangeRingsSetting embedded />
       </div>
     </CollapsiblePanel>

--- a/Frontend/components/velocityVectorLookaheadSetting.tsx
+++ b/Frontend/components/velocityVectorLookaheadSetting.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+import {
+  useVelocityVectorLookahead,
+  VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES,
+  VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES,
+  VELOCITY_VECTOR_LOOKAHEAD_STEP_MINUTES,
+} from "@/context/velocityVectorLookaheadContext";
+
+const VelocityVectorLookaheadSetting = ({
+  embedded = false,
+}: {
+  embedded?: boolean;
+}) => {
+  const { durationMinutes, setDurationMinutes } = useVelocityVectorLookahead();
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDurationMinutes(Number(event.target.value));
+  };
+
+  const content = (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <label
+          htmlFor="velocityVectorLookahead"
+          className="font-bold text-atc-text font-mono tracking-wider text-xs shrink-0"
+        >
+          速度ベクトル予測時間:
+        </label>
+        <span className="text-atc-text font-mono text-xs tabular-nums">
+          {durationMinutes} 分
+        </span>
+      </div>
+      <input
+        id="velocityVectorLookahead"
+        type="range"
+        min={VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES}
+        max={VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES}
+        step={VELOCITY_VECTOR_LOOKAHEAD_STEP_MINUTES}
+        value={durationMinutes}
+        onChange={handleChange}
+        className="w-full h-1.5 bg-atc-surface-elevated rounded-full appearance-none cursor-pointer
+                   accent-atc-accent
+                   [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
+                   [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-atc-accent"
+      />
+      <div className="flex justify-between text-[10px] font-mono text-atc-text-muted">
+        <span>{VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES}分</span>
+        <span>{VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES}分</span>
+      </div>
+    </div>
+  );
+
+  if (embedded) {
+    return content;
+  }
+  return (
+    <div className="bg-atc-surface border border-atc-border rounded-lg p-3 mb-3">
+      {content}
+    </div>
+  );
+};
+
+export default VelocityVectorLookaheadSetting;

--- a/Frontend/context/velocityVectorLookaheadContext.test.ts
+++ b/Frontend/context/velocityVectorLookaheadContext.test.ts
@@ -1,0 +1,42 @@
+import {
+  clampVelocityVectorLookaheadMinutes,
+  VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES,
+  VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES,
+  VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES,
+  VELOCITY_VECTOR_LOOKAHEAD_STEP_MINUTES,
+} from "./velocityVectorLookaheadContext";
+
+describe("clampVelocityVectorLookaheadMinutes", () => {
+  it("clamps to min/max and snaps to step", () => {
+    expect(clampVelocityVectorLookaheadMinutes(0)).toBe(
+      VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES
+    );
+    expect(clampVelocityVectorLookaheadMinutes(99)).toBe(
+      VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES
+    );
+    expect(clampVelocityVectorLookaheadMinutes(1.24)).toBe(1);
+    expect(clampVelocityVectorLookaheadMinutes(1.26)).toBe(1.5);
+  });
+
+  it("leaves allowed values unchanged", () => {
+    expect(clampVelocityVectorLookaheadMinutes(1)).toBe(
+      VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES
+    );
+    expect(clampVelocityVectorLookaheadMinutes(10)).toBe(
+      VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES
+    );
+    expect(clampVelocityVectorLookaheadMinutes(0.5)).toBe(
+      VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES
+    );
+    expect(clampVelocityVectorLookaheadMinutes(7.5)).toBe(7.5);
+  });
+
+  it("preserves each allowed 0.5 minute step", () => {
+    for (let i = 0; i < 20; i += 1) {
+      const v =
+        VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES +
+        i * VELOCITY_VECTOR_LOOKAHEAD_STEP_MINUTES;
+      expect(clampVelocityVectorLookaheadMinutes(v)).toBeCloseTo(v, 6);
+    }
+  });
+});

--- a/Frontend/context/velocityVectorLookaheadContext.tsx
+++ b/Frontend/context/velocityVectorLookaheadContext.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+export const VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES = 0.5;
+export const VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES = 10;
+export const VELOCITY_VECTOR_LOOKAHEAD_STEP_MINUTES = 0.5;
+export const VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES = 1;
+
+const STORAGE_KEY = "horus.velocityVectorLookaheadMinutes";
+
+export function clampVelocityVectorLookaheadMinutes(value: number): number {
+  const step = VELOCITY_VECTOR_LOOKAHEAD_STEP_MINUTES;
+  const min = VELOCITY_VECTOR_LOOKAHEAD_MIN_MINUTES;
+  const max = VELOCITY_VECTOR_LOOKAHEAD_MAX_MINUTES;
+  const rounded = Math.round(value / step) * step;
+  return Math.min(max, Math.max(min, rounded));
+}
+
+function readStoredDurationMinutes(): number {
+  if (typeof window === "undefined") {
+    return VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES;
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw == null) return VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) {
+      return VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES;
+    }
+    return clampVelocityVectorLookaheadMinutes(parsed);
+  } catch {
+    return VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES;
+  }
+}
+
+export interface VelocityVectorLookaheadContextType {
+  durationMinutes: number;
+  setDurationMinutes: (value: number) => void;
+}
+
+export const VelocityVectorLookaheadContext = createContext<
+  VelocityVectorLookaheadContextType | undefined
+>(undefined);
+
+export const VelocityVectorLookaheadProvider: React.FC<{
+  children: ReactNode;
+}> = ({ children }) => {
+  const [durationMinutes, setDurationMinutesState] = useState(
+    VELOCITY_VECTOR_LOOKAHEAD_DEFAULT_MINUTES
+  );
+
+  useEffect(() => {
+    setDurationMinutesState(readStoredDurationMinutes());
+  }, []);
+
+  const setDurationMinutes = useCallback((value: number) => {
+    const next = clampVelocityVectorLookaheadMinutes(value);
+    setDurationMinutesState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {
+      /* quota / private mode */
+    }
+  }, []);
+
+  return (
+    <VelocityVectorLookaheadContext.Provider
+      value={{ durationMinutes, setDurationMinutes }}
+    >
+      {children}
+    </VelocityVectorLookaheadContext.Provider>
+  );
+};
+
+export const useVelocityVectorLookahead = () => {
+  const ctx = useContext(VelocityVectorLookaheadContext);
+  if (!ctx) {
+    throw new Error(
+      "useVelocityVectorLookahead must be used within a VelocityVectorLookaheadProvider"
+    );
+  }
+  return ctx;
+};

--- a/Frontend/utility/aircraft/drawAircraft.ts
+++ b/Frontend/utility/aircraft/drawAircraft.ts
@@ -29,7 +29,8 @@ class DrawAircraft {
     displayRange: DisplayRange,
     dataBlockDisplaySetting: DataBlockDisplaySetting,
     /** Controller 画面では管制クリアランス高度があれば 2 行目をクリアランス vs 実測にする（パイロット目標の古い値で矢印が狂うのを防ぐ）。 */
-    useControllerClearanceAltitudeRow = false
+    useControllerClearanceAltitudeRow = false,
+    durationMinutes = 1
   ) {
     this.drawAircraftMarker(ctx, aircraft.position);
     this.drawHeadingLine(
@@ -37,7 +38,8 @@ class DrawAircraft {
       aircraft.position,
       aircraft.vector.groundSpeed,
       aircraft.vector.heading,
-      displayRange
+      displayRange,
+      durationMinutes
     );
     this.drawLabelLiine(ctx, aircraft.position, aircraft.label);
     this.drawAircraftLabel(
@@ -66,7 +68,8 @@ class DrawAircraft {
     position: { x: number; y: number },
     groundSpeed: number,
     heading: number,
-    displayRange: DisplayRange
+    displayRange: DisplayRange,
+    durationMinutes: number
   ) {
     const futurePosition = CoordinateManager.calculateFuturePositionOnCanvas(
       groundSpeed,
@@ -74,7 +77,8 @@ class DrawAircraft {
       GLOBAL_SETTINGS.canvasWidth,
       GLOBAL_SETTINGS.canvasHeight,
       displayRange,
-      position
+      position,
+      durationMinutes
     );
 
     // Draw a line from the current position to the future position

--- a/Frontend/utility/coordinateManager/CoordinateManager.test.ts
+++ b/Frontend/utility/coordinateManager/CoordinateManager.test.ts
@@ -66,4 +66,56 @@ describe("CoordinateManager", () => {
       expect(geo.longitude).toBeCloseTo(point.longitude, 1);
     });
   });
+
+  describe("calculateFuturePositionOnCanvas", () => {
+    const futurePosBase = {
+      speed: 600,
+      heading: 90,
+      canvasWidth: 1000,
+      canvasHeight: 1000,
+      current: { x: 500, y: 500 },
+    } as const;
+
+    const callFuturePosition = (durationMinutes?: number) =>
+      durationMinutes === undefined
+        ? CoordinateManager.calculateFuturePositionOnCanvas(
+            futurePosBase.speed,
+            futurePosBase.heading,
+            futurePosBase.canvasWidth,
+            futurePosBase.canvasHeight,
+            displayRange,
+            futurePosBase.current
+          )
+        : CoordinateManager.calculateFuturePositionOnCanvas(
+            futurePosBase.speed,
+            futurePosBase.heading,
+            futurePosBase.canvasWidth,
+            futurePosBase.canvasHeight,
+            displayRange,
+            futurePosBase.current,
+            durationMinutes
+          );
+
+    it.each([
+      { minutesA: 1, minutesB: 2, ratio: 2 },
+      { minutesA: 1, minutesB: 3, ratio: 3 },
+      { minutesA: 0.5, minutesB: 2.5, ratio: 5 },
+    ])(
+      "scales displacement by durationMinutes ($minutesA vs $minutesB min → ratio $ratio)",
+      ({ minutesA, minutesB, ratio }) => {
+        const posA = callFuturePosition(minutesA);
+        const posB = callFuturePosition(minutesB);
+        const dxA = posA.futureX - futurePosBase.current.x;
+        const dxB = posB.futureX - futurePosBase.current.x;
+        expect(dxB).toBeCloseTo(dxA * ratio, 5);
+      }
+    );
+
+    it("defaults duration to 1 minute", () => {
+      const implicit = callFuturePosition();
+      const explicit = callFuturePosition(1);
+      expect(implicit.futureX).toBeCloseTo(explicit.futureX, 6);
+      expect(implicit.futureY).toBeCloseTo(explicit.futureY, 6);
+    });
+  });
 });

--- a/Frontend/utility/coordinateManager/CoordinateManager.ts
+++ b/Frontend/utility/coordinateManager/CoordinateManager.ts
@@ -5,7 +5,6 @@ import { DisplayRange } from "@/context/displayRangeContext";
 
 // 地球の丸みを考慮にいれ、緯度・経度をキャンバス上の座標に変換するクラス
 export class CoordinateManager {
-
   /**
    * 緯度・経度をキャンバス上の座標に変換します。
    * @param centerLatitude 中心の緯度
@@ -15,20 +14,38 @@ export class CoordinateManager {
    * @param targetLongitude 対象の経度
    * @returns キャンバス上の座標 {x, y}
    */
-  public static calculateCanvasCoordinates(pointCoordinate: Coordinate, centerCoordinate: Coordinate, displayRange: DisplayRange): { x: number, y: number } {
+  public static calculateCanvasCoordinates(
+    pointCoordinate: Coordinate,
+    centerCoordinate: Coordinate,
+    displayRange: DisplayRange
+  ): { x: number; y: number } {
     // Convert degrees to radians
     const toRadians = (degrees: number) => degrees * (Math.PI / 180);
 
     // Haversine formula to calculate the distance between two points on the Earth
-    const deltaLat = toRadians(pointCoordinate.latitude - centerCoordinate.latitude);
-    const deltaLon = toRadians(pointCoordinate.longitude - centerCoordinate.longitude);
-    const a = Math.sin(deltaLat / 2) ** 2 + Math.cos(toRadians(centerCoordinate.latitude)) * Math.cos(toRadians(pointCoordinate.latitude)) * Math.sin(deltaLon / 2) ** 2;
+    const deltaLat = toRadians(
+      pointCoordinate.latitude - centerCoordinate.latitude
+    );
+    const deltaLon = toRadians(
+      pointCoordinate.longitude - centerCoordinate.longitude
+    );
+    const a =
+      Math.sin(deltaLat / 2) ** 2 +
+      Math.cos(toRadians(centerCoordinate.latitude)) *
+        Math.cos(toRadians(pointCoordinate.latitude)) *
+        Math.sin(deltaLon / 2) ** 2;
     const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     const distanceKm = GLOBAL_CONSTANTS.EARTH_RADIUS_KM * c;
 
     // Calculate the bearing from the center to the point
-    const y = Math.sin(deltaLon) * Math.cos(toRadians(pointCoordinate.latitude));
-    const x = Math.cos(toRadians(centerCoordinate.latitude)) * Math.sin(toRadians(pointCoordinate.latitude)) - Math.sin(toRadians(centerCoordinate.latitude)) * Math.cos(toRadians(pointCoordinate.latitude)) * Math.cos(deltaLon);
+    const y =
+      Math.sin(deltaLon) * Math.cos(toRadians(pointCoordinate.latitude));
+    const x =
+      Math.cos(toRadians(centerCoordinate.latitude)) *
+        Math.sin(toRadians(pointCoordinate.latitude)) -
+      Math.sin(toRadians(centerCoordinate.latitude)) *
+        Math.cos(toRadians(pointCoordinate.latitude)) *
+        Math.cos(deltaLon);
     const bearing = Math.atan2(y, x);
 
     // Scale distance to canvas pixels
@@ -37,8 +54,10 @@ export class CoordinateManager {
     const distancePx = distanceKm * pixelsPerKm;
 
     // Calculate canvas coordinates
-    const canvasX = (GLOBAL_SETTINGS.canvasWidth / 2) + distancePx * Math.sin(bearing);
-    const canvasY = (GLOBAL_SETTINGS.canvasHeight / 2) - distancePx * Math.cos(bearing);
+    const canvasX =
+      GLOBAL_SETTINGS.canvasWidth / 2 + distancePx * Math.sin(bearing);
+    const canvasY =
+      GLOBAL_SETTINGS.canvasHeight / 2 - distancePx * Math.cos(bearing);
 
     return { x: canvasX, y: canvasY };
   }
@@ -51,15 +70,20 @@ export class CoordinateManager {
    * @param displayRange 表示領域の1辺の長さ（キロメートル）
    * @returns 緯度・経度 {latitude, longitude}
    */
-  public static calculateGeoCoordinates(canvasX: number, canvasY: number, centerCoordinate: Coordinate, displayRange: DisplayRange): { latitude: number, longitude: number } {
+  public static calculateGeoCoordinates(
+    canvasX: number,
+    canvasY: number,
+    centerCoordinate: Coordinate,
+    displayRange: DisplayRange
+  ): { latitude: number; longitude: number } {
     // Convert degrees to radians
     const toRadians = (degrees: number) => degrees * (Math.PI / 180);
     // Convert radians to degrees
     const toDegrees = (radians: number) => radians * (180 / Math.PI);
 
     // Calculate the distance from the center of the canvas
-    const deltaX = canvasX - (GLOBAL_SETTINGS.canvasWidth / 2);
-    const deltaY = (GLOBAL_SETTINGS.canvasHeight / 2) - canvasY;
+    const deltaX = canvasX - GLOBAL_SETTINGS.canvasWidth / 2;
+    const deltaY = GLOBAL_SETTINGS.canvasHeight / 2 - canvasY;
     const distancePx = Math.sqrt(deltaX ** 2 + deltaY ** 2);
 
     // Scale pixels to kilometers
@@ -73,18 +97,26 @@ export class CoordinateManager {
     const angularDistance = distanceKm / GLOBAL_CONSTANTS.EARTH_RADIUS_KM;
 
     const newLatitude = Math.asin(
-        Math.sin(toRadians(centerCoordinate.latitude)) * Math.cos(angularDistance) +
-        Math.cos(toRadians(centerCoordinate.latitude)) * Math.sin(angularDistance) * Math.cos(bearing)
+      Math.sin(toRadians(centerCoordinate.latitude)) *
+        Math.cos(angularDistance) +
+        Math.cos(toRadians(centerCoordinate.latitude)) *
+          Math.sin(angularDistance) *
+          Math.cos(bearing)
     );
 
-    const newLongitude = toRadians(centerCoordinate.longitude) + Math.atan2(
-        Math.sin(bearing) * Math.sin(angularDistance) * Math.cos(toRadians(centerCoordinate.latitude)),
-        Math.cos(angularDistance) - Math.sin(toRadians(centerCoordinate.latitude)) * Math.sin(newLatitude)
-    );
+    const newLongitude =
+      toRadians(centerCoordinate.longitude) +
+      Math.atan2(
+        Math.sin(bearing) *
+          Math.sin(angularDistance) *
+          Math.cos(toRadians(centerCoordinate.latitude)),
+        Math.cos(angularDistance) -
+          Math.sin(toRadians(centerCoordinate.latitude)) * Math.sin(newLatitude)
+      );
 
     return {
-        latitude: toDegrees(newLatitude),
-        longitude: toDegrees(newLongitude)
+      latitude: toDegrees(newLatitude),
+      longitude: toDegrees(newLongitude),
     };
   }
 
@@ -94,7 +126,7 @@ export class CoordinateManager {
    * @returns ラジアン
    */
   private degToRad(deg: number): number {
-      return deg * (Math.PI / 180);
+    return deg * (Math.PI / 180);
   }
 
   /**
@@ -105,58 +137,60 @@ export class CoordinateManager {
    * @param lon2 座標2の経度
    * @returns 距離（キロメートル）
    */
-  public calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
-      const dLat = this.degToRad(lat2 - lat1);
-      const dLon = this.degToRad(lon2 - lon1);
-      const a =
-          Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-          Math.cos(this.degToRad(lat1)) * Math.cos(this.degToRad(lat2)) *
-          Math.sin(dLon / 2) * Math.sin(dLon / 2);
-      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-      const distance = GLOBAL_CONSTANTS.EARTH_RADIUS_KM * c;
-      return distance;
+  public calculateDistance(
+    lat1: number,
+    lon1: number,
+    lat2: number,
+    lon2: number
+  ): number {
+    const dLat = this.degToRad(lat2 - lat1);
+    const dLon = this.degToRad(lon2 - lon1);
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(this.degToRad(lat1)) *
+        Math.cos(this.degToRad(lat2)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    const distance = GLOBAL_CONSTANTS.EARTH_RADIUS_KM * c;
+    return distance;
   }
 
-/**
- * Calculates the canvas position of an aircraft 1 minute into the future based on its current speed and heading.
- * @param speed - Current speed of the aircraft in knots.
- * @param heading - Current heading of the aircraft in degrees.
- * @param canvasWidth - Width of the canvas in pixels.
- * @param canvasHeight - Height of the canvas in pixels.
- * @param displayRange - The width of the displayed airspace in kilometers.
- * @param currentPosition - Current position of the aircraft on the canvas in pixels.
- * @returns The position of the aircraft on the canvas after 1 minute.
- */
-public static calculateFuturePositionOnCanvas(
+  /**
+   * Calculates the canvas endpoint of the velocity vector from current speed and heading.
+   * Uses displacement = (1 minute of travel at current speed) × `durationMinutes` (default 1).
+   * @param durationMinutes - Lookahead time in minutes (e.g. 0.5–10).
+   */
+  public static calculateFuturePositionOnCanvas(
     speed: number,
     heading: number,
     canvasWidth: number,
     canvasHeight: number,
     displayRange: DisplayRange,
-    currentPosition: { x: number; y: number }
+    currentPosition: { x: number; y: number },
+    durationMinutes: number = 1
   ): { futureX: number; futureY: number } {
     // Convert speed from knots to kilometers per minute
-    const speedKmPerMin = speed * 1.852 / 60;
-  
+    const speedKmPerMin = (speed * 1.852) / 60;
+
     // Convert heading from degrees to radians
     const headingRad = (heading - 90) * (Math.PI / 180);
-  
-    // Calculate the distance traveled in x and y directions
-    const deltaX = speedKmPerMin * Math.cos(headingRad);
-    const deltaY = - speedKmPerMin * Math.sin(headingRad);
-  
-    // Calculate the new position in kilometers
-    const futurePositionX = currentPosition.x + deltaX;
-    const futurePositionY = currentPosition.y + deltaY;
-  
-    // Convert the future position from kilometers to canvas pixels
+
+    // Ground displacement (km) over `durationMinutes` (1-minute basis × minutes).
+    const deltaXKm = speedKmPerMin * Math.cos(headingRad) * durationMinutes;
+    const deltaYKm = -speedKmPerMin * Math.sin(headingRad) * durationMinutes;
+
     const kmPerPixel = displayRange.range / canvasWidth;
-    const futureX = currentPosition.x + (futurePositionX - currentPosition.x) / kmPerPixel;
-    const futureY = currentPosition.y - (futurePositionY - currentPosition.y) / kmPerPixel;
-  
+    const deltaXPx = deltaXKm / kmPerPixel;
+    // Screen Y is down-positive; combined with the velocity Y convention, use −(km→px).
+    const deltaYPx = -deltaYKm / kmPerPixel;
+
+    const futureX = currentPosition.x + deltaXPx;
+    const futureY = currentPosition.y + deltaYPx;
+
     return {
       futureX: Math.min(Math.max(futureX, 0), canvasWidth),
-      futureY: Math.min(Math.max(futureY, 0), canvasHeight)
+      futureY: Math.min(Math.max(futureY, 0), canvasHeight),
     };
   }
 }

--- a/spec/20260404-velocity-vector-line-duration/spec.md
+++ b/spec/20260404-velocity-vector-line-duration/spec.md
@@ -1,0 +1,106 @@
+# 速度ベクトル線の長さ（予測時間）調整（2-4）
+
+## メタデータ
+
+- **Status**: Draft
+- **Date**: 2026-04-04
+- **関連 Issue**: [#52](https://github.com/Futty93/Horus/issues/52)
+- **親インデックス**: [spec/spec.md Phase 2-4](../../spec/spec.md)
+
+## 概要
+
+レーダー上の各機の**速度ベクトル線**（針路方向の先端までの白線）は、現状 **固定で「現在から 1 分後の位置」**に相当する長さで描画されている。本 spec は、利用者が **予測時間（分など）を設定パネルから変更**できるようにし、訓練・デモの見え方を調整できるようにする。バックエンドのシミュレーション計算は変更しない（**表示のみ**）。
+
+## 背景・課題
+
+### 現状
+
+- `CoordinateManager.calculateFuturePositionOnCanvas` が地速（kt）から **1 分間の移動**を仮定し、キャンバス上の終点を求めている（JSDoc も「1 minute」）。
+- `DrawAircraft.drawHeadingLine` が上記を用いてベクトル線を描画。
+- 利用者が長さを変えられないため、低速機では線が短く、高速機では長く見えるが **時間軸は常に 1 分**。
+
+### 課題（Problem Statement）
+
+- 教材やシナリオによっては **30 秒分・2 分分**など、見せたい「先読み時間」を変えたい。
+- 実運用レーダーでもベクトル長と時間の対応はシステム設定であり、**研究用シミュレータでも調整可能であるべき**。
+
+### なぜ今か（Motivation）
+
+- フェーズ 2 の「レーダー表示の強化」の一つで、**難易度低・UI のみ中心**（`spec/spec.md` ★☆☆）。既存のレンジリング等と同様、設定パネルへの追加で完結しやすい。
+
+---
+
+## 方針
+
+### 決定方針（Decision）
+
+1. **入力 UI はスライダー**とする。予測時間（分）の取りうる値は **0.5～10**、**ステップ 0.5 分**（0.5, 1, 1.5, …, 10）。既定の初期値は **1 分**（現状の 1 分先ベクトルと一致）。
+2. `calculateFuturePositionOnCanvas`（または呼び出し側）に **「分」倍率**を渡し、現状の 1 分相当の位移に **`durationMinutes` を乗算**する形で終点を計算する（数式の意図は「地速由来の 1 分位移 × 分」）。
+3. 設定は **フロントのみ**（React Context または既存のレーダー表示設定に準拠）。**永続化**は `localStorage` 等でも可。バックエンド API は不要。
+4. **Operator / Controller 両方**のレーダーで同一設定を共有するか、ページ別にするかは実装時に決定（既定は **グローバル Context で両画面共通**が簡潔）。
+
+### 検討した他案（Alternatives Considered）
+
+- **案 A**: ピクセル長を直接指定する。却下: 表示範囲（NM）とズームに依存し、**時間との対応が崩れる**。
+- **案 B**: 自由入力の数値フィールドのみ。却下: **スライダー + 0.5 分刻み**の方が誤入力が少なく、レンジが明確。
+
+### トレードオフ（Trade-offs）
+
+- **メリット**: 実装範囲が Canvas／座標系に閉じ、テストしやすい。仕様の意図が「時間」で説明しやすい。
+- **デメリット / 受容する制約**: 極端に長い時間を選ぶと終点が画面外にクリップされ、線が短く見える（現状どおり `Math.min/Math.max` でクリップ）。仕様上は許容。
+
+---
+
+## 完了条件（Success Criteria）
+
+- [ ] 設定パネルに **スライダー**があり、**0.5～10 分・0.5 分刻み**で速度ベクトル用の予測時間を変更できる。
+- [ ] 変更後、レーダー上のベクトル線の長さが **地速と設定時間に整合**して変化する。
+- [ ] 初期値は **1 分**（現状の 1 分先ベクトルと一致）。
+- [ ] `Frontend` の `npm run lint` / `npm test`（該当する場合）が通る。
+
+---
+
+## 影響範囲
+
+- **Frontend**: `CoordinateManager.calculateFuturePositionOnCanvas` の引数または内部計算、`DrawAircraft.drawHeadingLine`、新規または既存の Context（例: 表示設定）、設定 UI コンポーネント（レーダー周りのパネル）。
+- **Backend**: なし。
+- **ドキュメント**: `Frontend/README.md` のレーダー／設定の説明を更新。
+
+---
+
+## 実装計画
+
+### Phase 1 — 最小実装
+
+1. 定数: `MIN = 0.5`, `MAX = 10`, `STEP = 0.5`, 既定 `DEFAULT = 1`（分）。
+2. `calculateFuturePositionOnCanvas` に **分**パラメータを追加し、位移に反映。
+3. Context（または既存設定）に値を保持し、レーダー Canvas が参照。
+4. 設定パネルに **range スライダー**（`min` / `max` / `step` を上記に合わせる。ラベル例: Vector lookahead (min)／日本語併記は README）。
+5. 単体テスト: `CoordinateManager` の位移が **時間倍率に比例**すること（既存テストがあれば拡張）。
+
+### Phase 2 — 任意
+
+- `localStorage` への永続化。
+
+---
+
+## 検証
+
+- [ ] テストが通る
+- [ ] ビルドが通る
+- [ ] 手動で Operator / Controller の両方でベクトル長が変わることを確認
+
+---
+
+## 未解決事項（Unresolved Questions）
+
+- 設定を **Operator と Controller で共有**するか独立か（既定は共有）。
+
+---
+
+## 関連ドキュメント
+
+- [spec/spec.md Phase 2-4](../../spec/spec.md)
+- [Issue #52](https://github.com/Futty93/Horus/issues/52)
+- `Frontend/utility/coordinateManager/CoordinateManager.ts`（現行の 1 分先計算）
+- `Frontend/utility/aircraft/drawAircraft.ts`（ベクトル線描画）


### PR DESCRIPTION
## 概要

レーダー上の各機の**速度ベクトル線**の長さを、固定 1 分相当ではなく **0.5～10 分（0.5 分刻み）**で変更できるようにする。バックエンドのシミュレーションは変更せず**表示のみ**。`VelocityVectorLookaheadContext` と `localStorage` で Controller / Operator 間で設定を共有する。

## 実装の意図

- 教材・デモで「何分先まで見せるか」を変えたいという要望に対応する（[Issue #52](https://github.com/Futty93/Horus/issues/52)、Phase 2-4）。
- 既存の `calculateFuturePositionOnCanvas` は 1 分位移に時間倍率を掛ける形で拡張。
- `CoordinateManager.calculateFuturePositionOnCanvas` 内の km/px 計算を、**差分（km）→ ピクセル換算 → 加算**に整理し、単位の紛らわしさを減らした。

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [x] ドキュメント
- [ ] その他

## 変更内容

- `CoordinateManager.calculateFuturePositionOnCanvas` に `durationMinutes`（既定 1）を追加。位移の km/px 計算をリファクタ。
- `DrawAircraft` / `radarCanvas` で Context の予測時間を参照。
- `velocityVectorLookaheadContext`（`localStorage` 永続化）、`velocityVectorLookaheadSetting`（スライダー）、`RadarViewSetting` への組み込み。
- Controller / Operator の Provider 配下に `VelocityVectorLookaheadProvider` を追加。
- `Frontend/README.md` と spec `spec/20260404-velocity-vector-line-duration/spec.md` を更新。

## テスト

- [ ] 該当なし（既存ロジックの変更のみ）
- [x] テストを追加した（`Frontend/` のテスト）
- [ ] テストは未追加（理由を備考に記載）

追加・更新: `CoordinateManager.test.ts`（`calculateFuturePositionOnCanvas`）、`velocityVectorLookaheadContext.test.ts`（clamp）。

## 関連 issue / 実装計画

- Closes #52（該当すればマージ時に閉じる想定で記載。不要なら編集してください）
- [spec/20260404-velocity-vector-line-duration/spec.md](spec/20260404-velocity-vector-line-duration/spec.md)

## 動作確認

- [ ] バックエンドのテストが通る（`./gradlew test`）※本 PR はフロントのみ変更
- [x] フロントエンドのビルドが通る（`npm run build`）
- [x] フロントのテストが通る（`npm test`）
- [ ] 手動で動作確認した（レビュアーまたはマージ前に Controller / Operator でスライダーとベクトル長を確認推奨）

## 備考

- ブランチ: `feat/velocity-vector-lookahead`
