### PR TITLE
feat(frontend): Phase 4 conflict BFF, STCA UI, and backend conflict fixes

### DIFF
--- a/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/domain/model/service/conflict/ConflictDetector.java
+++ b/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/domain/model/service/conflict/ConflictDetector.java
@@ -104,8 +104,13 @@ public class ConflictDetector {
             // CPA分析による最接近点計算
             CPAResult cpaResult = calculateCPA(aircraft1, aircraft2);
 
-            // 危険度評価の実行
-            double riskLevel = assessRiskLevel(cpaResult);
+            AircraftPosition pos1 = aircraft1.getAircraftPosition();
+            AircraftPosition pos2 = aircraft2.getAircraftPosition();
+            double currentHorizontalNm = GeodeticUtils.calculateHorizontalDistance(pos1, pos2);
+            double currentVerticalFt = GeodeticUtils.calculateVerticalDistance(pos1, pos2);
+
+            // 危険度評価の実行（現在隔離は測地距離、最接近は CPA 結果）
+            double riskLevel = assessRiskLevel(cpaResult, currentHorizontalNm, currentVerticalFt);
             boolean isConflictPredicted = predictSeparationViolation(cpaResult);
 
             return new RiskAssessment(
@@ -340,14 +345,13 @@ public class ConflictDetector {
     /**
      * CPA結果に基づくリスク評価
      */
-    private double assessRiskLevel(CPAResult cpaResult) {
-        // 既存のcalculateRiskLevelメソッドを使用
+    private double assessRiskLevel(CPAResult cpaResult, double currentHorizontalNm, double currentVerticalFt) {
         return calculateRiskLevel(
             cpaResult.timeToClosest,
             cpaResult.horizontalDistance,
             cpaResult.verticalDistance,
-            cpaResult.horizontalDistance, // 現在距離として使用
-            cpaResult.verticalDistance   // 現在距離として使用
+            currentHorizontalNm,
+            currentVerticalFt
         );
     }
 

--- a/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/interfaces/api/ConflictAlertController.java
+++ b/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/interfaces/api/ConflictAlertController.java
@@ -6,7 +6,11 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.application.ConflictAlertService;
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.interfaces.dto.ConflictAlertDto;
@@ -19,7 +23,6 @@ import jp.ac.tohoku.qse.takahashi.AtcSimulator.interfaces.dto.RiskAssessmentDto;
  */
 @RestController
 @RequestMapping("/api/conflict")
-@CrossOrigin(origins = "*")
 public class ConflictAlertController {
 
     private static final Logger logger = LoggerFactory.getLogger(ConflictAlertController.class);

--- a/Backend/src/test/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/domain/model/service/conflict/ConflictDetectorTest.java
+++ b/Backend/src/test/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/domain/model/service/conflict/ConflictDetectorTest.java
@@ -21,6 +21,7 @@ import jp.ac.tohoku.qse.takahashi.AtcSimulator.domain.model.valueObject.Conflict
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.domain.model.valueObject.Position.AircraftPosition;
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.domain.model.valueObject.Position.AircraftVector;
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.domain.model.valueObject.Type.AircraftType;
+import jp.ac.tohoku.qse.takahashi.AtcSimulator.shared.utility.GeodeticUtils;
 
 /**
  * ConflictDetectorの包括的なテストクラス
@@ -415,6 +416,31 @@ class ConflictDetectorTest {
             assertTrue(result.getRiskLevel() > 0.0 && result.getRiskLevel() <= 50.0,
                 "並行飛行でも間隔不足では適度な危険度");
             assertEquals(Double.POSITIVE_INFINITY, result.getTimeToClosest());
+        }
+
+        @Test
+        @DisplayName("すれ違い後は測地距離の現在隔離でリスクを評価し CPA 距離だけで張り付かない")
+        void testPostEncounterUsesGeodeticCurrentSeparationNotCpa() {
+            Aircraft westbound = createTestAircraft("WEST", 35.0, 139.0, 35000, 270, 400, 0);
+            Aircraft eastbound = createTestAircraft("EAST", 35.0, 139.28, 35000, 90, 400, 0);
+
+            RiskAssessment result = conflictDetector.calculateConflictRisk(westbound, eastbound);
+
+            double currentHorizontalNm = GeodeticUtils.calculateHorizontalDistance(
+                westbound.getAircraftPosition(),
+                eastbound.getAircraftPosition()
+            );
+
+            assertTrue(result.getTimeToClosest() < 0.0, "すれ違い後は最接近時刻が負");
+            assertTrue(
+                currentHorizontalNm > MINIMUM_HORIZONTAL_SEPARATION * 2,
+                "現位置は水平方向に十分離れている");
+            assertTrue(
+                result.getClosestHorizontalDistance() < MINIMUM_HORIZONTAL_SEPARATION,
+                "CPA では狭い接近だった");
+            assertTrue(
+                result.getRiskLevel() <= 25.0,
+                "現在隔離が大きいすれ違い後は低リスク");
         }
 
         @Test

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -110,6 +110,7 @@ Frontend/
 │   └── layout.tsx         # 共通レイアウト
 ├── components/            # 再利用可能なコンポーネント
 │   ├── radarCanvas.tsx    # レーダー表示キャンバス
+│   ├── conflictSummaryStrip.tsx # STCA 統計（ConflictStatisticsDto）をレーダー左上にポーリング表示
 │   ├── controlAircraft.tsx # 航空機制御パネル（Operator 専用）
 │   ├── instructionMemo.tsx # 指示メモ（Controller 専用）
 │   ├── selectFixMode.tsx  # Fix選択モード
@@ -124,6 +125,8 @@ Frontend/
 ├── tailwind.config.ts   # ATC テーマ設定
 └── public/             # 静的ファイル
 ```
+
+**STCA（コンフリクト）BFF**: `app/api/conflict/*` が Java `ConflictAlertController` の `/api/conflict/all`・`filtered`・`critical`・`violations`・`statistics`・`health`・`aircraft/{callsign}` へプロキシする。クライアント型・取得ヘルパーは `utility/api/conflict.ts`。
 
 ## 主要コンポーネント
 

--- a/Frontend/app/api/conflict/aircraft/[callsign]/route.ts
+++ b/Frontend/app/api/conflict/aircraft/[callsign]/route.ts
@@ -1,0 +1,18 @@
+import { proxyToBackend } from "@/utility/api/backendProxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  context: { params: { callsign: string } }
+) {
+  const raw = context.params.callsign;
+  const callsign = encodeURIComponent(raw);
+  return proxyToBackend(`/api/conflict/aircraft/${callsign}`, {
+    method: "GET",
+    headers: {
+      Accept: request.headers.get("Accept") ?? "application/json",
+    },
+    cache: "no-store",
+  });
+}

--- a/Frontend/app/api/conflict/all/route.ts
+++ b/Frontend/app/api/conflict/all/route.ts
@@ -1,0 +1,13 @@
+import { proxyToBackend } from "@/utility/api/backendProxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  return proxyToBackend("/api/conflict/all", {
+    method: "GET",
+    headers: {
+      Accept: request.headers.get("Accept") ?? "application/json",
+    },
+    cache: "no-store",
+  });
+}

--- a/Frontend/app/api/conflict/critical/route.ts
+++ b/Frontend/app/api/conflict/critical/route.ts
@@ -1,0 +1,13 @@
+import { proxyToBackend } from "@/utility/api/backendProxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  return proxyToBackend("/api/conflict/critical", {
+    method: "GET",
+    headers: {
+      Accept: request.headers.get("Accept") ?? "application/json",
+    },
+    cache: "no-store",
+  });
+}

--- a/Frontend/app/api/conflict/filtered/route.ts
+++ b/Frontend/app/api/conflict/filtered/route.ts
@@ -1,0 +1,16 @@
+import { proxyToBackend } from "@/utility/api/backendProxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const level = url.searchParams.get("level")?.trim() || "WHITE_CONFLICT";
+  const qs = new URLSearchParams({ level });
+  return proxyToBackend(`/api/conflict/filtered?${qs.toString()}`, {
+    method: "GET",
+    headers: {
+      Accept: request.headers.get("Accept") ?? "application/json",
+    },
+    cache: "no-store",
+  });
+}

--- a/Frontend/app/api/conflict/health/route.ts
+++ b/Frontend/app/api/conflict/health/route.ts
@@ -1,0 +1,13 @@
+import { proxyToBackend } from "@/utility/api/backendProxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  return proxyToBackend("/api/conflict/health", {
+    method: "GET",
+    headers: {
+      Accept: request.headers.get("Accept") ?? "application/json",
+    },
+    cache: "no-store",
+  });
+}

--- a/Frontend/app/api/conflict/statistics/route.ts
+++ b/Frontend/app/api/conflict/statistics/route.ts
@@ -1,0 +1,13 @@
+import { proxyToBackend } from "@/utility/api/backendProxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  return proxyToBackend("/api/conflict/statistics", {
+    method: "GET",
+    headers: {
+      Accept: request.headers.get("Accept") ?? "application/json",
+    },
+    cache: "no-store",
+  });
+}

--- a/Frontend/app/api/conflict/violations/route.ts
+++ b/Frontend/app/api/conflict/violations/route.ts
@@ -1,0 +1,13 @@
+import { proxyToBackend } from "@/utility/api/backendProxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  return proxyToBackend("/api/conflict/violations", {
+    method: "GET",
+    headers: {
+      Accept: request.headers.get("Accept") ?? "application/json",
+    },
+    cache: "no-store",
+  });
+}

--- a/Frontend/app/controller/page.tsx
+++ b/Frontend/app/controller/page.tsx
@@ -15,6 +15,7 @@ import { SelectedAircraftProvider } from "@/context/selectedAircraftContext";
 import SelectedCallsignDisplay from "@/components/selectedCallsignDisplay";
 import FlightPlanDisplay from "@/components/flightPlanDisplay";
 import InstructionMemo from "@/components/instructionMemo";
+import ConflictSummaryStrip from "@/components/conflictSummaryStrip";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -32,8 +33,11 @@ export default function ControllerPage() {
                 <SelectFixModeProvider>
                   <SelectedAircraftProvider>
                     <div className="flex h-screen w-full">
-                      <div className="flex w-full">
-                        <RadarCanvas />
+                      <div className="flex min-h-0 w-full min-w-0 flex-1">
+                        <div className="relative h-full min-h-0 min-w-0 flex-1">
+                          <ConflictSummaryStrip />
+                          <RadarCanvas />
+                        </div>
                         <div
                           className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
                               p-4 flex flex-col justify-between min-w-80 max-w-80

--- a/Frontend/app/operator/page.tsx
+++ b/Frontend/app/operator/page.tsx
@@ -16,6 +16,7 @@ import SelectFixMode from "@/components/selectFixMode";
 import SelectedCallsignDisplay from "@/components/selectedCallsignDisplay";
 import FlightPlanControl from "@/components/flightPlanControl";
 import SimulationControlButtons from "@/components/simulationControlButtons";
+import ConflictSummaryStrip from "@/components/conflictSummaryStrip";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -33,8 +34,11 @@ export default function OperatorPage() {
                 <SelectFixModeProvider>
                   <SelectedAircraftProvider>
                     <div className="flex h-screen w-full overflow-hidden">
-                      <div className="flex w-full h-full">
-                        <RadarCanvas />
+                      <div className="flex h-full min-h-0 w-full min-w-0 flex-1">
+                        <div className="relative h-full min-h-0 min-w-0 flex-1">
+                          <ConflictSummaryStrip />
+                          <RadarCanvas />
+                        </div>
                         <div
                           className="controlPanel bg-atc-bg border-l border-atc-border text-atc-text
                                   p-3 flex flex-col min-w-80 max-w-80

--- a/Frontend/components/conflictSummaryStrip.tsx
+++ b/Frontend/components/conflictSummaryStrip.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { GLOBAL_CONSTANTS } from "@/utility/globals/constants";
+import {
+  fetchConflictStatistics,
+  type ConflictStatisticsDto,
+} from "@/utility/api/conflict";
+
+const ConflictSummaryStrip: React.FC = () => {
+  const [stats, setStats] = useState<ConflictStatisticsDto | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      const next = await fetchConflictStatistics();
+      if (!cancelled) {
+        setStats(next);
+      }
+    };
+    void tick();
+    const id = setInterval(
+      () => void tick(),
+      GLOBAL_CONSTANTS.LOCATION_UPDATE_INTERVAL
+    );
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (stats == null) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute left-3 top-3 z-10 max-w-[min(100%-1.5rem,24rem)] rounded border border-atc-border bg-atc-surface/90 px-3 py-1.5 text-xs text-atc-text shadow-sm backdrop-blur-sm"
+      aria-live="polite"
+    >
+      <span className="text-atc-text-muted">STCA</span>{" "}
+      <span className="font-medium text-atc-danger">
+        R {stats.redConflictCount}
+      </span>
+      <span className="text-atc-text-muted"> · </span>
+      <span className="font-medium text-atc-warning">
+        W {stats.whiteConflictCount}
+      </span>
+      <span className="text-atc-text-muted"> · </span>
+      <span>Sep {stats.separationViolationCount}</span>
+      <span className="text-atc-text-muted"> · </span>
+      <span className="text-atc-text-muted">pairs {stats.totalConflicts}</span>
+    </div>
+  );
+};
+
+export default ConflictSummaryStrip;

--- a/Frontend/components/radarCanvas.tsx
+++ b/Frontend/components/radarCanvas.tsx
@@ -206,9 +206,10 @@ const RadarCanvas: React.FC = () => {
     const canvas = canvasRefs[idx]?.current;
     if (!canvas) return;
 
+    const nowMs = performance.now();
     clearCanvas(ctx, canvas);
     renderMapOnCanvas(ctx);
-    renderAircraftsOnCanvas(ctx);
+    renderAircraftsOnCanvas(ctx, nowMs);
 
     toggleCanvasDisplay();
   };
@@ -238,7 +239,10 @@ const RadarCanvas: React.FC = () => {
     drawRangeRings(ctx, displayRangeRef.current, rangeRingsSettingRef.current);
   };
 
-  const renderAircraftsOnCanvas = (ctx: CanvasRenderingContext2D) => {
+  const renderAircraftsOnCanvas = (
+    ctx: CanvasRenderingContext2D,
+    nowMs: number
+  ) => {
     controllingAircraftsRef.current.forEach((aircraft) => {
       DrawAircraft.drawAircraft(
         ctx,
@@ -247,7 +251,8 @@ const RadarCanvas: React.FC = () => {
         centerCoordinateRef.current,
         dataBlockDisplaySettingRef.current,
         controllerClearanceAltitudeRowRef.current,
-        velocityVectorDurationRef.current
+        velocityVectorDurationRef.current,
+        nowMs
       );
     });
   };
@@ -415,7 +420,7 @@ const RadarCanvas: React.FC = () => {
   };
 
   return (
-    <div className="radarArea relative w-full">
+    <div className="radarArea relative h-full w-full">
       <canvas ref={canvasRefs[0]} className="w-full h-full bg-black"></canvas>
       <canvas ref={canvasRefs[1]} className="w-full hidden"></canvas>
     </div>

--- a/Frontend/components/radarCanvas.tsx
+++ b/Frontend/components/radarCanvas.tsx
@@ -24,6 +24,18 @@ import { useSelectedAircraft } from "@/context/selectedAircraftContext";
 import { searchFixName } from "@/utility/AtsRouteManager/FixNameSearch";
 import { usePathname } from "next/navigation";
 
+function resetCanvas2dState(ctx: CanvasRenderingContext2D): void {
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.globalAlpha = 1;
+  ctx.globalCompositeOperation = "source-over";
+  ctx.lineWidth = 1;
+  ctx.lineCap = "butt";
+  ctx.lineJoin = "miter";
+  ctx.setLineDash([]);
+  ctx.shadowBlur = 0;
+  ctx.shadowColor = "transparent";
+}
+
 const RadarCanvas: React.FC = () => {
   const canvasRefs = [
     useRef<HTMLCanvasElement>(null),
@@ -208,6 +220,7 @@ const RadarCanvas: React.FC = () => {
 
     const nowMs = performance.now();
     clearCanvas(ctx, canvas);
+    resetCanvas2dState(ctx);
     renderMapOnCanvas(ctx);
     renderAircraftsOnCanvas(ctx, nowMs);
 

--- a/Frontend/utility/AtsRouteManager/routeRenderer.ts
+++ b/Frontend/utility/AtsRouteManager/routeRenderer.ts
@@ -207,6 +207,7 @@ function drawLineBetweenPoints(
   ctx.lineTo(point2Coordinate.x, point2Coordinate.y);
   ctx.globalAlpha = 0.7; // Set opacity for waypoints
   ctx.strokeStyle = color; // Line color
+  ctx.lineWidth = 1;
   ctx.stroke();
 
   // Draw black circle under the marker

--- a/Frontend/utility/aircraft/drawAircraft.ts
+++ b/Frontend/utility/aircraft/drawAircraft.ts
@@ -37,10 +37,16 @@ class DrawAircraft {
     dataBlockDisplaySetting: DataBlockDisplaySetting,
     /** Controller 画面では管制クリアランス高度があれば 2 行目をクリアランス vs 実測にする（パイロット目標の古い値で矢印が狂うのを防ぐ）。 */
     useControllerClearanceAltitudeRow = false,
-    durationMinutes = 1
+    durationMinutes = 1,
+    nowMs = performance.now()
   ) {
     this.drawTrack(ctx, aircraft, centerCoordinate, displayRange);
-    this.drawAircraftMarker(ctx, aircraft.position);
+    this.drawAircraftMarker(
+      ctx,
+      aircraft.position,
+      aircraft.riskLevel ?? 0,
+      nowMs
+    );
     this.drawHeadingLine(
       ctx,
       aircraft.position,
@@ -85,9 +91,26 @@ class DrawAircraft {
 
   private static drawAircraftMarker(
     ctx: CanvasRenderingContext2D,
-    position: { x: number; y: number }
+    position: { x: number; y: number },
+    riskLevel: number,
+    nowMs: number
   ) {
     const radius: number = 5;
+    const flashOn = Math.floor(nowMs / 450) % 2 === 0;
+
+    if (riskLevel >= 70 && flashOn) {
+      ctx.beginPath();
+      ctx.arc(position.x, position.y, radius + 6, 0, 2 * Math.PI);
+      ctx.strokeStyle = "rgba(207, 34, 34, 0.9)";
+      ctx.lineWidth = 3;
+      ctx.stroke();
+    } else if (riskLevel >= 30) {
+      ctx.beginPath();
+      ctx.arc(position.x, position.y, radius + 4, 0, 2 * Math.PI);
+      ctx.strokeStyle = "rgba(158, 106, 3, 0.95)";
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
 
     ctx.beginPath();
     ctx.arc(position.x, position.y, radius, 0, 2 * Math.PI);

--- a/Frontend/utility/aircraft/drawAircraft.ts
+++ b/Frontend/utility/aircraft/drawAircraft.ts
@@ -29,6 +29,17 @@ import {
  * @see CanvasRenderingContext2D
  */
 class DrawAircraft {
+  /** Same integer as the data-block `R` row; drives STCA ring thresholds so R0 never gets a ring from float/NaN quirks. */
+  private static computeRiskDisplayFloor(aircraft: Aircraft): number {
+    const raw = aircraft.riskLevel;
+    const n =
+      typeof raw === "number" && Number.isFinite(raw) ? raw : Number(raw);
+    if (!Number.isFinite(n)) {
+      return 0;
+    }
+    return Math.floor(Math.max(0, Math.min(100, n)));
+  }
+
   public static drawAircraft(
     ctx: CanvasRenderingContext2D,
     aircraft: Aircraft,
@@ -40,28 +51,30 @@ class DrawAircraft {
     durationMinutes = 1,
     nowMs = performance.now()
   ) {
-    this.drawTrack(ctx, aircraft, centerCoordinate, displayRange);
-    this.drawAircraftMarker(
-      ctx,
-      aircraft.position,
-      aircraft.riskLevel ?? 0,
-      nowMs
-    );
-    this.drawHeadingLine(
-      ctx,
-      aircraft.position,
-      aircraft.vector.groundSpeed,
-      aircraft.vector.heading,
-      displayRange,
-      durationMinutes
-    );
-    this.drawLabelLiine(ctx, aircraft.position, aircraft.label);
-    this.drawAircraftLabel(
-      ctx,
-      aircraft,
-      dataBlockDisplaySetting,
-      useControllerClearanceAltitudeRow
-    );
+    const riskDisplayFloor = this.computeRiskDisplayFloor(aircraft);
+    ctx.save();
+    try {
+      this.drawTrack(ctx, aircraft, centerCoordinate, displayRange);
+      this.drawAircraftMarker(ctx, aircraft.position, riskDisplayFloor, nowMs);
+      this.drawHeadingLine(
+        ctx,
+        aircraft.position,
+        aircraft.vector.groundSpeed,
+        aircraft.vector.heading,
+        displayRange,
+        durationMinutes
+      );
+      this.drawLabelLiine(ctx, aircraft.position, aircraft.label);
+      this.drawAircraftLabel(
+        ctx,
+        aircraft,
+        dataBlockDisplaySetting,
+        useControllerClearanceAltitudeRow,
+        riskDisplayFloor
+      );
+    } finally {
+      ctx.restore();
+    }
   }
 
   private static drawTrack(
@@ -92,13 +105,13 @@ class DrawAircraft {
   private static drawAircraftMarker(
     ctx: CanvasRenderingContext2D,
     position: { x: number; y: number },
-    riskLevel: number,
+    riskDisplayFloor: number,
     nowMs: number
   ) {
     const radius: number = 5;
     const flashOn = Math.floor(nowMs / 450) % 2 === 0;
 
-    if (riskLevel >= 70) {
+    if (riskDisplayFloor >= 70) {
       if (flashOn) {
         ctx.beginPath();
         ctx.arc(position.x, position.y, radius + 6, 0, 2 * Math.PI);
@@ -106,7 +119,7 @@ class DrawAircraft {
         ctx.lineWidth = 3;
         ctx.stroke();
       }
-    } else if (riskLevel >= 30) {
+    } else if (riskDisplayFloor >= 30) {
       ctx.beginPath();
       ctx.arc(position.x, position.y, radius + 4, 0, 2 * Math.PI);
       ctx.strokeStyle = "rgba(158, 106, 3, 0.95)";
@@ -150,7 +163,8 @@ class DrawAircraft {
     ctx: CanvasRenderingContext2D,
     aircraft: Aircraft,
     setting: DataBlockDisplaySetting,
-    useControllerClearanceAltitudeRow: boolean
+    useControllerClearanceAltitudeRow: boolean,
+    riskDisplayFloor: number
   ) {
     const airplanePosition = aircraft.position;
     const instructedVector = aircraft.instructedVector;
@@ -174,11 +188,10 @@ class DrawAircraft {
             airplanePosition.altitude
           );
 
-    const riskLevel = aircraft.riskLevel || 0;
     let riskColor = "white";
-    if (riskLevel >= 70) {
+    if (riskDisplayFloor >= 70) {
       riskColor = "red";
-    } else if (riskLevel >= 30) {
+    } else if (riskDisplayFloor >= 30) {
       riskColor = "yellow";
     }
 
@@ -227,7 +240,7 @@ class DrawAircraft {
     }
 
     ctx.fillStyle = riskColor;
-    ctx.fillText("R" + Math.floor(riskLevel).toString(), labelX, lineY);
+    ctx.fillText("R" + riskDisplayFloor.toString(), labelX, lineY);
     lineY += lineHeight;
 
     if (setting.aircraftType && aircraft.model) {
@@ -272,6 +285,7 @@ class DrawAircraft {
     ctx.moveTo(aircraftPosition.x + 10 * cos, aircraftPosition.y - 10 * sin);
     ctx.lineTo(labelX - 5, labelY + 15);
     ctx.strokeStyle = "white";
+    ctx.lineWidth = 1;
     ctx.stroke();
   }
 }

--- a/Frontend/utility/aircraft/drawAircraft.ts
+++ b/Frontend/utility/aircraft/drawAircraft.ts
@@ -98,12 +98,14 @@ class DrawAircraft {
     const radius: number = 5;
     const flashOn = Math.floor(nowMs / 450) % 2 === 0;
 
-    if (riskLevel >= 70 && flashOn) {
-      ctx.beginPath();
-      ctx.arc(position.x, position.y, radius + 6, 0, 2 * Math.PI);
-      ctx.strokeStyle = "rgba(207, 34, 34, 0.9)";
-      ctx.lineWidth = 3;
-      ctx.stroke();
+    if (riskLevel >= 70) {
+      if (flashOn) {
+        ctx.beginPath();
+        ctx.arc(position.x, position.y, radius + 6, 0, 2 * Math.PI);
+        ctx.strokeStyle = "rgba(207, 34, 34, 0.9)";
+        ctx.lineWidth = 3;
+        ctx.stroke();
+      }
     } else if (riskLevel >= 30) {
       ctx.beginPath();
       ctx.arc(position.x, position.y, radius + 4, 0, 2 * Math.PI);
@@ -140,6 +142,7 @@ class DrawAircraft {
     ctx.moveTo(position.x, position.y);
     ctx.lineTo(futurePosition.futureX, futurePosition.futureY);
     ctx.strokeStyle = "white";
+    ctx.lineWidth = 1;
     ctx.stroke();
   }
 

--- a/Frontend/utility/api/conflict.ts
+++ b/Frontend/utility/api/conflict.ts
@@ -1,0 +1,73 @@
+export interface RiskAssessmentDto {
+  riskLevel: number;
+  alertLevel: string;
+  timeToClosest: number;
+  closestHorizontalDistance: number;
+  closestVerticalDistance: number;
+  conflictPredicted: boolean;
+}
+
+export interface ConflictAlertDto {
+  pairId: string;
+  riskLevel: number;
+  alertLevel: string;
+  timeToClosest: number;
+  closestHorizontalDistance: number;
+  closestVerticalDistance: number;
+  conflictPredicted: boolean;
+}
+
+export interface ConflictStatisticsDto {
+  totalConflicts: number;
+  safeCount: number;
+  whiteConflictCount: number;
+  redConflictCount: number;
+  separationViolationCount: number;
+  maxRiskLevel: number;
+  avgRiskLevel: number;
+}
+
+async function fetchJson<T>(path: string): Promise<T | null> {
+  try {
+    const response = await fetch(path, {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchConflictStatistics(): Promise<ConflictStatisticsDto | null> {
+  return fetchJson<ConflictStatisticsDto>("/api/conflict/statistics");
+}
+
+export async function fetchConflictAll(): Promise<Record<
+  string,
+  RiskAssessmentDto
+> | null> {
+  return fetchJson<Record<string, RiskAssessmentDto>>("/api/conflict/all");
+}
+
+export async function fetchConflictCritical(): Promise<
+  ConflictAlertDto[] | null
+> {
+  return fetchJson<ConflictAlertDto[]>("/api/conflict/critical");
+}
+
+export async function fetchConflictViolations(): Promise<
+  ConflictAlertDto[] | null
+> {
+  return fetchJson<ConflictAlertDto[]>("/api/conflict/violations");
+}
+
+export async function fetchAircraftConflicts(
+  callsign: string
+): Promise<ConflictAlertDto[] | null> {
+  const encoded = encodeURIComponent(callsign);
+  return fetchJson<ConflictAlertDto[]>(`/api/conflict/aircraft/${encoded}`);
+}

--- a/spec/20260509-phase4-conflict-bff-ui/spec.md
+++ b/spec/20260509-phase4-conflict-bff-ui/spec.md
@@ -1,0 +1,91 @@
+# Phase 4 — Conflict API BFF・レーダー STCA 表示（スライス 1）
+
+## メタデータ
+
+- **Status**: Done
+- **Date**: 2026-05-09
+
+## 概要
+
+バックエンド `ConflictAlertController`（`/api/conflict/*`）を Next.js BFF 経由でフロントから利用可能にし、Controller / Operator のレーダー上に **STCA 統計ストリップ**と **リスクに応じた機体シンボル強調（リング＋赤レベル時の点滅）**を追加する。Phase 4-1 / 4-3 の一部を満たす縦切り。
+
+## 背景・課題
+
+### 現状
+
+- `ConflictAlertController` と DTO は実装済み。
+- フロントは `GET /aircraft/location/all` の `riskLevel` のみ利用し、`/api/conflict` を呼んでいなかった（[spec/spec.md](../spec.md) のギャップ表どおり）。
+
+### 課題（Problem Statement）
+
+- レーダー訓練でペア統計・違反件数を UI に出せない。
+- シンボルは常に同一の白マーカーで、ラベル `Rxx` 以外の視覚的 STCA が弱い。
+
+### なぜ今か（Motivation）
+
+- ロードマップ「推奨着手順」3 に沿い、BFF 接続と描画強調を先に入れると 4-2（ペア数値）や将来の選択機との突合の土台になる。
+
+---
+
+## 方針
+
+### 決定方針（Decision）
+
+1. **BFF**: `proxyToBackend` で Java のパスをそのまま転送（`/api/conflict/...`）。`LocationService` が `/aircraft` 直下であることとは異なるが、バックエンド実装に合わせる。
+2. **クライアント**: `utility/api/conflict.ts` に DTO 型と `fetchConflictStatistics` 等を定義。位置更新と同じ `LOCATION_UPDATE_INTERVAL` で統計をポーリング。
+3. **UI**: `ConflictSummaryStrip` をレーダー左上に絶対配置（`ConflictStatisticsDto`）。
+4. **描画**: `drawAircraft` のマーカーで `riskLevel >= 30` を黄系リング、`>= 70` を赤リングの点滅（`performance.now()` ベース）。
+
+### 検討した他案（Alternatives Considered）
+
+- **位置 API に統計を載せる**: バックエンド変更が大きいため却下。将来まとめてもよい。
+- **WebSocket**: Phase 7 領域のため今回はポーリングのまま。
+
+### トレードオフ（Trade-offs）
+
+- **メリット**: OpenAPI 変更なし、既存 DTO に追従するだけ。
+- **デメリット**: ポーリングが 1 本増える（間隔は位置と同じ 1s）。
+
+---
+
+## 完了条件（Success Criteria）
+
+- [x] `app/api/conflict/**` が `ConflictAlertController` の GET と対応している。
+- [x] `/controller`・`/operator` で STCA ストリップが表示され、統計が更新される（バックエンド起動時）。
+- [x] `riskLevel` に応じて機体マーカーにリング強調・赤レベル時点滅がある。
+- [x] `npm test` / `npm run lint`（Frontend）が通る。
+
+---
+
+## 影響範囲
+
+- **Frontend**: `app/api/conflict/*`、`utility/api/conflict.ts`、`conflictSummaryStrip.tsx`、`radarCanvas.tsx`、`drawAircraft.ts`、`controller` / `operator` ページ、`Frontend/README.md`
+- **Backend**: 変更なし
+
+---
+
+## 実装計画
+
+### Phase 1（本 spec の範囲）
+
+1. BFF ルート追加（all / filtered / critical / violations / statistics / health / aircraft/{callsign}）。
+2. クライアント API とストリップ、描画強調。
+
+### 後続（別 spec / Issue）
+
+- 4-2: 選択機またはラベル横へのペア距離（`getAircraftConflicts` 等の利用）。
+- 4-1 残り: 閾値・表示設定 UI、ペア強調の連動。
+
+---
+
+## 検証
+
+- [x] `npm test` / `npm run lint`（Frontend）
+- [ ] 手動: バックエンド＋フロント起動、衝突検知サンプル機でストリップとマーカー変化を確認
+
+---
+
+## 関連ドキュメント
+
+- [spec/spec.md](../spec.md) — Phase 4 ロードマップ
+- `Backend/.../ConflictAlertController.java`

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -61,7 +61,7 @@
 |------|----------------|-------------|
 | **Phase 1（入口）** | 上記フローは実装済み。 | 1-1〜1-4 は**コア Done**（子 spec 2026-05-09 更新済）。**残り**: Optional・手動 E2E・Issue #45–#47 の Close 運用。1-5 は未着手。 |
 | **Phase 2（レーダー）** | 履歴ドット・レンジリング・速度ベクトル時間は **Canvas ＋ Context で動作**。データブロックは **表示トグルと描画**あり。スクオーク行は **プレースホルダ**（`drawAircraft.ts`、Backend 未連携）。 | 2-1・2-2・2-4 はロードマップ上「未着手」扱いが不整合。**残りは拡張（点数・間隔の設定、子 spec の DoD との一致確認）** と 2-3 の **実データ連携（3-1 と接続）**、2-5・2-6。 |
-| **Phase 4（安全 UI）** | `riskLevel` は API → `Aircraft` → ラベル色（赤/黄）と `R` 行表示。 | **シンボル点滅・ペア強調・Conflict API のフロント未使用**（grep で Frontend に `conflict` 呼び出し無し）。4-1 は「強調の強化」、4-2〜4-3 は **BFF + `ConflictAlertController` 利用**が次の一手。 |
+| **Phase 4（安全 UI）** | `riskLevel` は API → `Aircraft` → ラベル色（赤/黄）と `R` 行表示。**BFF `/api/conflict/*`・STCA ストリップ・シンボルリング**は [20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)。 | **残り**: ペア数値ラベル（4-2）、強通知（4-3）、シンボル/閾値 UI の仕上げ（4-1）。 |
 | **シミュレーション速度（5-1）** | `AtcSimulatorConstants.REFRESH_RATE` が静的。 | 動的変更 API とスケジューラの見直しが必要。 |
 | **命名負債（T-2）** | `interfaces/api` に `*Service` が複数残存。 | `FlightPlanController` / `ScenarioController` と混在。リネームは OpenAPI・BFF・README を一括追従。 |
 
@@ -117,9 +117,9 @@
 
 | # | タスク | 状況 | 優先度 | 難易度 | Issue | 実装の所在 / 次の具体タスク |
 |---|--------|------|--------|--------|-------|---------------------------|
-| 4-1 | STCA 視覚強調 | 🔄 | 🔴 | ★☆☆ | [#60](https://github.com/Futty93/Horus/issues/60) | `riskLevel` によるラベル色・`R` 表示は実装済み。**未了**: シンボル本体の強調、点滅、閾値の設定 UI 等。 |
-| 4-2 | ペア間隔の数値表示 | ⬜ | 🟡 | ★★☆ | [#61](https://github.com/Futty93/Horus/issues/61) | Backend `ConflictAlertController` 利用。**新規**: BFF `app/api/...` + ラベル横またはサイドパネル。 |
-| 4-3 | 間隔違反の明示通知 | ⬜ | 🟡 | ★★☆ | [#62](https://github.com/Futty93/Horus/issues/62) | `ConflictStatisticsDto` を UI に接続（ポーリング間隔と負荷に注意）。 |
+| 4-1 | STCA 視覚強調 | 🔄 | 🔴 | ★☆☆ | [#60](https://github.com/Futty93/Horus/issues/60) | `riskLevel` によるラベル色・`R` 表示に加え、**シンボルリング強調・赤レベル時の点滅**（[20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)）。**残り**: 閾値の設定 UI、ペア連動強調。 |
+| 4-2 | ペア間隔の数値表示 | ⬜ | 🟡 | ★★☆ | [#61](https://github.com/Futty93/Horus/issues/61) | BFF は [20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md) で整備済み。**新規**: ラベル横またはサイドパネルで `getAircraftConflicts` 等を表示。 |
+| 4-3 | 間隔違反の明示通知 | 🔄 | 🟡 | ★★☆ | [#62](https://github.com/Futty93/Horus/issues/62) | **STCA ストリップ**で `ConflictStatisticsDto`（Sep / R / W / pairs）を表示（[20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)）。**残り**: トースト・サイドパネル等の強い通知。 |
 | 4-4 | MSAW 簡易版 | ⬜ | 🟢 | ★★☆ | [#63](https://github.com/Futty93/Horus/issues/63) | 最低高度しきい値と `AircraftLocationDto` 拡張または別エンドポイント。 |
 
 ---
@@ -179,7 +179,7 @@
 2. **（並行）T-3** — ✅ **完了**（[20260509-t3-flight-plan-tests-docs](20260509-t3-flight-plan-tests-docs/spec.md)）。次は **Phase 4**（Conflict UI）または Phase 2 残り。
 
 3. **Phase 4 のフロント接続（4-1 強化 → 4-2 / 4-3）**  
-   Backend は `ConflictAlertController` 済み。**BFF + ポーリング**でペア情報・統計を取り、レーダー上の強調とセットで実装すると一貫する。4-1 の「シンボル強調」は `drawAircraft.ts` の拡張。
+   **スライス 1 完了**: BFF・統計ストリップ・シンボル強調（[20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)）。**次**: 4-2 ペア間隔表示、`getAircraftConflicts` の UI 接続、4-3 のトースト等。
 
 4. **Phase 2 の残り（2-5、2-6 の仕上げ、2-3 のデータ連携準備）**  
    2-1・2-2・2-4 は実装済みのため、**新規は主に 2-5 とメモ spec の仕上げ**。2-3 のスクオーク実値は **3-1 と同一スプリント**にすると二度手間が減る。
@@ -206,6 +206,7 @@ Phase 1 spec/Issue 整合 ──→ T-3（並行）
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-09 | Phase 4 スライス: Conflict BFF・STCA ストリップ・シンボル強調（[20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)）。4-1/4-3 を部分完了に更新。 |
 | 2026-05-09 | T-3 完了（テスト・サンプル・README・マトリクス）。着手順 2 を完了扱いに。 |
 | 2026-05-09 | T-3 着手用 spec 追加: [20260509-t3-flight-plan-tests-docs](20260509-t3-flight-plan-tests-docs/spec.md)。T-3 行・着手順 2 にリンク。 |
 | 2026-05-09 | Phase 1 子 spec 整合実施（1-2〜1-4 を Done 扱いに更新）。着手順 1 を完了扱いに。 |


### PR DESCRIPTION
## Summary

This branch delivers Phase 4 conflict awareness in the Frontend (BFF routes, STCA strip, risk rings on radar symbols) and fixes backend issues that blocked or distorted conflict data.

## Frontend

- Next.js BFF under `app/api/conflict/*` proxying the backend conflict/statistics endpoints.
- `ConflictSummaryStrip` (STCA one-liner) and integration with Controller/Operator radar.
- Aircraft symbol risk rings; canvas state fixes so route lines do not inherit STCA stroke; alignment of rings with the risk row using integer risk and per-aircraft save/restore.

## Backend

- **CORS:** Remove `@CrossOrigin(origins = "*")` from `ConflictAlertController` so it follows global `WebConfig` (credentials + explicit origins). The wildcard plus `allowCredentials(true)` caused Spring to throw and return 500 on conflict requests.
- **Risk model:** `ConflictDetector` now passes **geodetic current** horizontal/vertical separation into `calculateRiskLevel` instead of duplicating CPA distances as "current", which inflated risk when aircraft were actually separated (especially after closest approach). Adds a regression test for the diverging case.

## Testing

- `./gradlew test --tests ConflictDetectorTest` (and Spotless on commit).

## Notes

- If the Java backend is stopped, the BFF still returns 500 with `ECONNREFUSED`; ensure Uranus/Backend is running for local dev.

Made with [Cursor](https://cursor.com)