### PR TITLE
refactor(conflict-api): extract health status DTO

### DIFF
--- a/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/interfaces/api/ConflictAlertController.java
+++ b/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/interfaces/api/ConflictAlertController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.application.ConflictAlertService;
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.interfaces.dto.ConflictAlertDto;
 import jp.ac.tohoku.qse.takahashi.AtcSimulator.interfaces.dto.ConflictStatisticsDto;
+import jp.ac.tohoku.qse.takahashi.AtcSimulator.interfaces.dto.HealthStatusDto;
 
 /**
  * コンフリクトアラート機能のREST APIコントローラー
@@ -137,40 +138,18 @@ public class ConflictAlertController {
      * @return システム状態
      */
     @GetMapping("/health")
-    public ResponseEntity<HealthStatus> getHealthStatus() {
+    public ResponseEntity<HealthStatusDto> getHealthStatus() {
         logger.debug("ヘルスチェック要求");
 
         ConflictStatisticsDto statistics = conflictAlertService.getConflictStatistics();
-        HealthStatus status = new HealthStatus(
+        HealthStatusDto status = new HealthStatusDto(
             "OK",
             System.currentTimeMillis(),
             statistics.totalConflicts(),
             statistics.redConflictCount()
         );
 
-        logger.debug("ヘルスチェック完了: ステータス={}", status.getStatus());
+        logger.debug("ヘルスチェック完了: ステータス={}", status.status());
         return ResponseEntity.ok(status);
-    }
-
-    /**
-     * ヘルスステータス情報を表すクラス
-     */
-    public static class HealthStatus {
-        private final String status;
-        private final long timestamp;
-        private final long totalConflicts;
-        private final long criticalConflicts;
-
-        public HealthStatus(String status, long timestamp, long totalConflicts, long criticalConflicts) {
-            this.status = status;
-            this.timestamp = timestamp;
-            this.totalConflicts = totalConflicts;
-            this.criticalConflicts = criticalConflicts;
-        }
-
-        public String getStatus() { return status; }
-        public long getTimestamp() { return timestamp; }
-        public long getTotalConflicts() { return totalConflicts; }
-        public long getCriticalConflicts() { return criticalConflicts; }
     }
 }

--- a/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/interfaces/dto/HealthStatusDto.java
+++ b/Backend/src/main/java/jp/ac/tohoku/qse/takahashi/AtcSimulator/interfaces/dto/HealthStatusDto.java
@@ -1,0 +1,11 @@
+package jp.ac.tohoku.qse.takahashi.AtcSimulator.interfaces.dto;
+
+/**
+ * DTO for conflict API health endpoint response.
+ */
+public record HealthStatusDto(
+    String status,
+    long timestamp,
+    long totalConflicts,
+    long criticalConflicts
+) {}

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -118,7 +118,7 @@
 
 | # | タスク | 状況 | 優先度 | 難易度 | Issue | 実装の所在 / 次の具体タスク |
 |---|--------|------|--------|--------|-------|---------------------------|
-| 4-1 | STCA 視覚強調 | 🔄 | 🔴 | ★☆☆ | [#60](https://github.com/Futty93/Horus/issues/60) | `riskLevel` によるラベル色・`R` 表示に加え、**シンボルリング強調・赤レベル時の点滅**（[20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)）。**残り**: 閾値の設定 UI、ペア連動強調。 |
+| 4-1 | STCA 視覚強調 | 🔄 | 🟢 | ★☆☆ | [#60](https://github.com/Futty93/Horus/issues/60) | `riskLevel` によるラベル色・`R` 表示に加え、**シンボルリング強調・赤レベル時の点滅**（[20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)）。**残り**: 閾値の設定 UI、ペア連動強調。**現時点では優先度を下げ、当面は後回し**。 |
 | 4-2 | ペア間隔の数値表示 | ⬜ | 🟡 | ★★☆ | [#61](https://github.com/Futty93/Horus/issues/61) | 着手用子 spec [20260509-phase4-conflict-pair-ui-alerts](20260509-phase4-conflict-pair-ui-alerts/spec.md)。BFF 済み。**新規**: ラベル横またはサイドで `fetchAircraftConflicts` 等を表示。 |
 | 4-3 | 間隔違反の明示通知 | 🔄 | 🟡 | ★★☆ | [#62](https://github.com/Futty93/Horus/issues/62) | ストリップは [20260509-phase4-conflict-bff-ui](20260509-phase4-conflict-bff-ui/spec.md)。**残り（強通知）**は [20260509-phase4-conflict-pair-ui-alerts](20260509-phase4-conflict-pair-ui-alerts/spec.md)。 |
 | 4-4 | MSAW 簡易版 | ⬜ | 🟢 | ★★☆ | [#63](https://github.com/Futty93/Horus/issues/63) | 最低高度しきい値と `AircraftLocationDto` 拡張または別エンドポイント。 |
@@ -208,6 +208,7 @@ Phase 1 spec/Issue 整合 ──→ T-3（並行）
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-09 | Phase 4-1（STCA 視覚強調）は既存の点滅・リング強調で当面運用し、残タスク（閾値 UI・ペア連動強調）は優先度を 🟢 に下げて後回し方針を明記。 |
 | 2026-05-09 | Phase 3-2（ホールディング `HOLD`）の着手用 spec を追加（[20260509-phase3-holding-pattern](20260509-phase3-holding-pattern/spec.md)）。 |
 | 2026-05-09 | Phase 3-1b（特定 Squawk 強調表示）の着手用 spec を追加（[20260509-phase3-squawk-highlight-filter](20260509-phase3-squawk-highlight-filter/spec.md)）。 |
 | 2026-05-09 | Phase 3-1（スクオーク割当・表示）の着手用 spec を追加（[20260509-phase3-squawk-assignment-display](20260509-phase3-squawk-assignment-display/spec.md)）。 |


### PR DESCRIPTION
## Summary
- Extract `HealthStatus` from `ConflictAlertController` into `HealthStatusDto` under `interfaces/dto` for API response consistency.
- Update `/api/conflict/health` to return `ResponseEntity<HealthStatusDto>` and remove controller inner class.
- Update `spec/spec.md` to mark remaining STCA visual polish (4-1) as lower priority/deferred for now.

## Test plan
- [x] `cd Backend && ./gradlew test --tests "*ConflictAlert*"`
- [x] Pre-commit Java formatting/check hooks passed (`spotlessApply` / `spotlessCheck`).
- [ ] Optional: manually call `/api/conflict/health` and confirm response keys are unchanged (`status`, `timestamp`, `totalConflicts`, `criticalConflicts`).


Made with [Cursor](https://cursor.com)